### PR TITLE
Add executed_at to approvals and implement idempotent approve/reject flows with events and intent detection

### DIFF
--- a/dev_schema.sql
+++ b/dev_schema.sql
@@ -6,5 +6,6 @@ create table if not exists hermes_approvals (
   status text not null default 'pending',
   requested_at timestamptz default now(),
   approved_at timestamptz,
-  rejected_at timestamptz
+  rejected_at timestamptz,
+  executed_at timestamptz
 );

--- a/gbrain.js
+++ b/gbrain.js
@@ -35,6 +35,9 @@ async function ensureGBrainSchema() {
 
     alter table hermes_tasks
       add column if not exists issue_number bigint;
+
+    alter table hermes_approvals
+      add column if not exists executed_at timestamptz;
   `);
 
 }

--- a/index.js
+++ b/index.js
@@ -656,6 +656,8 @@ if (callback) {
     const taskId = data.split("_")[1];
 
     await sendTelegramMessage(chatId, `Đã từ chối task ${taskId}`);
+
+    await handleAction(`từ chối task ${taskId}`, chatId);
   }
 
   continue;

--- a/worker.js
+++ b/worker.js
@@ -223,7 +223,9 @@ async function runSafeCommand(taskId, command) {
        values ($1, 'command_requires_approval', $2, 'pending')`,
       [taskId, command]
     );
-  
+
+    await event(taskId, 'approval_requested', `Risky command requires approval: ${command}`, { command });
+
   const taskRow = await query(
   `select telegram_chat_id from hermes_tasks where id=$1`,
   [taskId]
@@ -264,6 +266,7 @@ return "Đang chờ bạn duyệt...";
 async function classifyIntent(text) {
   const intent = detectIntent(text);
   console.log("INTENT:", intent, "| TEXT:", text);
+  return intent;
 }
 
 async function loadMemories() {
@@ -297,6 +300,18 @@ function buildSimpleDiff(oldContent, newContent) {
 
 function detectIntent(text) {
   const lower = text.toLowerCase();
+
+  if (lower.includes("chạy lệnh")) {
+    return "run_command";
+  }
+
+  if (lower.includes("duyệt task")) {
+    return "approve_task";
+  }
+
+  if (lower.includes("từ chối task")) {
+    return "reject_task";
+  }
 
   // recall memory
   if (lower.includes("nhớ gì") || lower.includes("memory")) {
@@ -830,24 +845,62 @@ return [
 
   const targetTaskId = Number(match[0]);
 
-  const result = await query(
-    `select * from hermes_approvals
-     where task_id=$1 and status='pending'
-     order by id desc limit 1`,
+  const approveResult = await query(
+    `with picked as (
+       select id
+       from hermes_approvals
+       where task_id=$1 and status='pending'
+       order by id desc
+       limit 1
+     )
+     update hermes_approvals a
+     set status='approved', approved_at=now()
+     from picked
+     where a.id = picked.id
+       and a.status = 'pending'
+     returning a.*`,
     [targetTaskId]
   );
 
-  const approval = result.rows[0];
-  if (!approval) return `Không có approval pending cho task #${targetTaskId}`;
+  const approval = approveResult.rows[0];
+  if (!approval) {
+    const latest = await query(
+      `select * from hermes_approvals where task_id=$1 order by id desc limit 1`,
+      [targetTaskId]
+    );
 
-  await query(
+    const latestApproval = latest.rows[0];
+    if (!latestApproval) return `Không có approval cho task #${targetTaskId}`;
+    if (latestApproval.status === "rejected") {
+      return `Task #${targetTaskId} đã bị từ chối trước đó.`;
+    }
+    if (latestApproval.status === "approved" && latestApproval.executed_at) {
+      return `Task #${targetTaskId} đã được duyệt và chạy trước đó, không chạy lại.`;
+    }
+    return `Không có approval pending cho task #${targetTaskId}`;
+  }
+
+  await event(task.id, "approval_decided", `Approved risky command for task #${targetTaskId}`, {
+    approvalId: approval.id,
+    command: approval.command,
+    decision: "approved",
+  });
+
+  const executeGate = await query(
     `update hermes_approvals
-     set status='approved', approved_at=now()
-     where id=$1`,
+     set executed_at=now()
+     where id=$1
+       and status='approved'
+       and executed_at is null
+     returning *`,
     [approval.id]
   );
 
-  // 🔥 CHẠY LỆNH SAU KHI DUYỆT
+  if (!executeGate.rows[0]) {
+    return `Task #${targetTaskId} đã được xử lý trước đó, không chạy lại.`;
+  }
+
+  // 🔥 CHẠY LỆNH SAU KHI DUYỆT (idempotent)
   try {
     const { stdout, stderr } = await execAsync(approval.command, {
   cwd: PROJECT_ROOT,
@@ -863,6 +916,45 @@ const output = [stdout, stderr].filter(Boolean).join("\n") || "Lệnh chạy xon
     return `Đã duyệt nhưng chạy lệnh lỗi:\n${err.message}`;
   }
 }  
+
+
+  if (intent === "reject_task") {
+    const match = text.match(/\d+/);
+    if (!match) return "Bạn cần nói: từ chối task 12";
+
+    const targetTaskId = Number(match[0]);
+
+    const result = await query(
+      `with picked as (
+         select id
+         from hermes_approvals
+         where task_id=$1 and status='pending'
+         order by id desc
+         limit 1
+       )
+       update hermes_approvals a
+       set status='rejected', rejected_at=now()
+       from picked
+       where a.id = picked.id
+         and a.status = 'pending'
+       returning a.*`,
+      [targetTaskId]
+    );
+
+    const approval = result.rows[0];
+    if (!approval) return `Không có approval pending cho task #${targetTaskId}`;
+
+    await event(task.id, "approval_decided", `Rejected risky command for task #${targetTaskId}`, {
+      approvalId: approval.id,
+      command: approval.command,
+      decision: "rejected",
+    });
+
+    return `Đã từ chối task #${targetTaskId} ❌
+
+Lệnh không được chạy:
+${approval.command}`;
+  }
 
 
   const memories = await loadMemories();


### PR DESCRIPTION
### Motivation

- Ensure risky command approvals are recorded as executed to prevent double execution by adding an `executed_at` marker to approvals. 
- Make the approve/reject flow atomic and idempotent so commands are run exactly once after approval. 
- Improve UX by detecting Vietnamese intents and triggering the appropriate approval or rejection actions from Telegram callbacks.

### Description

- Added `executed_at timestamptz` to `hermes_approvals` in `dev_schema.sql` and to the runtime migrations in `gbrain.js` to support execution tracking. 
- When a risky command is blocked, `runSafeCommand` now inserts a pending approval and emits an `approval_requested` event with the command details. 
- Added intent detection for Vietnamese phrases mapping to `run_command`, `approve_task`, and `reject_task` in `detectIntent` and ensured `classifyIntent` returns the detected intent. 
- Implemented atomic CTE-based approve and reject flows that update approval rows (`approved_at`/`rejected_at`), set `executed_at` when executing, emit `approval_decided` events, and ensure commands are executed only once; rejection returns a clear message and does not run the command. 
- Wired Telegram rejection callbacks in `index.js` to call `handleAction` for rejection like approvals. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2c526a6cc8333b5d6ac2be9f03360)