### PR TITLE
Introduce dispatcher subsystem: planning, execution, approval, events, and memory recall

### DIFF
--- a/dispatcher/approval.ts
+++ b/dispatcher/approval.ts
@@ -1,0 +1,50 @@
+import { logEvent } from "./events";
+import { validateTransition } from "./fsm";
+import { Queryable, TaskStatus } from "./types";
+
+async function updateStatusTx(db: Queryable, taskId: number, from: TaskStatus, to: TaskStatus): Promise<void> {
+  validateTransition(from, to);
+  const res = await db.query(
+    `UPDATE hermes_tasks SET status = $1 WHERE id = $2 AND status = $3`,
+    [to, taskId, from],
+  );
+  if ((res.rowCount ?? 0) === 0) throw new Error(`Race condition updating task ${taskId} ${from} -> ${to}`);
+}
+
+export async function approveTask(db: Queryable, taskId: number): Promise<void> {
+  await db.query("BEGIN");
+  try {
+    await updateStatusTx(db, taskId, "pending_approval", "approved");
+    await logEvent(db, taskId, "approved", "Task approved", {});
+    await db.query("COMMIT");
+  } catch (error) {
+    await db.query("ROLLBACK");
+    throw error;
+  }
+}
+
+export async function rejectTask(db: Queryable, taskId: number): Promise<void> {
+  await db.query("BEGIN");
+  try {
+    await updateStatusTx(db, taskId, "pending_approval", "failed");
+    await logEvent(db, taskId, "rejected", "Task rejected", {});
+    await db.query("COMMIT");
+  } catch (error) {
+    await db.query("ROLLBACK");
+    throw error;
+  }
+}
+
+export async function requireApprovalIfHighRisk(db: Queryable, taskId: number, riskLevel: string): Promise<boolean> {
+  if (riskLevel !== "high") return false;
+  await db.query("BEGIN");
+  try {
+    await updateStatusTx(db, taskId, "planned", "pending_approval");
+    await logEvent(db, taskId, "approval_required", "High-risk task requires approval", {});
+    await db.query("COMMIT");
+    return true;
+  } catch (error) {
+    await db.query("ROLLBACK");
+    throw error;
+  }
+}

--- a/dispatcher/errors.ts
+++ b/dispatcher/errors.ts
@@ -1,0 +1,29 @@
+export interface NormalizedError {
+  message: string;
+  type: string;
+  stack?: string;
+}
+
+export function normalizeError(error: unknown): NormalizedError {
+  if (error instanceof Error) {
+    return {
+      message: error.message || "Unknown error",
+      type: error.name || "Error",
+      stack: error.stack ? error.stack.slice(0, 500).trim() : undefined,
+    };
+  }
+
+  if (typeof error === "object" && error !== null) {
+    const maybe = error as { message?: unknown; name?: unknown; stack?: unknown };
+    return {
+      message: typeof maybe.message === "string" && maybe.message.length > 0 ? maybe.message : "Unknown error",
+      type: typeof maybe.name === "string" && maybe.name.length > 0 ? maybe.name : "Error",
+      stack: typeof maybe.stack === "string" ? maybe.stack.slice(0, 500).trim() : undefined,
+    };
+  }
+
+  return {
+    message: typeof error === "string" && error.length > 0 ? error : "Unknown error",
+    type: "Error",
+  };
+}

--- a/dispatcher/events.ts
+++ b/dispatcher/events.ts
@@ -1,0 +1,33 @@
+import { Queryable } from "./types";
+
+const IDEMPOTENT_EVENTS = new Set([
+  "plan_created",
+  "memory_loaded",
+  "approval_required",
+  "approved",
+  "rejected",
+]);
+
+export async function logEvent(
+  db: Queryable,
+  taskId: number,
+  eventType: string,
+  message: string,
+  metadata: Record<string, unknown> = {},
+): Promise<void> {
+  if (IDEMPOTENT_EVENTS.has(eventType)) {
+    const dup = await db.query(
+      `SELECT id FROM hermes_task_events WHERE task_id = $1 AND event_type = $2 LIMIT 1`,
+      [taskId, eventType],
+    );
+    if ((dup.rowCount ?? 0) > 0) {
+      return;
+    }
+  }
+
+  await db.query(
+    `INSERT INTO hermes_task_events (task_id, event_type, message, metadata)
+     VALUES ($1, $2, $3, $4::jsonb)`,
+    [taskId, eventType, message, JSON.stringify(metadata)],
+  );
+}

--- a/dispatcher/executor.ts
+++ b/dispatcher/executor.ts
@@ -1,0 +1,86 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { normalizeError } from "./errors";
+import { logEvent } from "./events";
+import { validateTransition } from "./fsm";
+import { Queryable, Task } from "./types";
+
+const execFileAsync = promisify(execFile);
+
+const ALLOWED_EXACT = new Set(["git status", "git diff", "npm run build", "npm run test", "npm run lint", "npm run typecheck"]);
+
+export class ExecutionBlockedError extends Error {}
+
+function isAllowed(command: string): boolean {
+  const trimmed = command.trim();
+  return ALLOWED_EXACT.has(trimmed) || trimmed.startsWith("node scripts/safe-");
+}
+
+function withResultSafety(output: string): { storedResult: string; fullOutput?: string } {
+  if (Buffer.byteLength(output, "utf8") <= 10 * 1024) {
+    return { storedResult: output };
+  }
+  const truncated = output.slice(0, 10 * 1024);
+  return { storedResult: truncated, fullOutput: output };
+}
+
+async function runCommandWithTimeout(command: string, timeoutMs = 60_000): Promise<string> {
+  const { stdout, stderr } = await execFileAsync("bash", ["-lc", command], { timeout: timeoutMs, maxBuffer: 1024 * 1024 });
+  return `${stdout ?? ""}${stderr ?? ""}`.trim();
+}
+
+export async function executeTask(db: Queryable, task: Task): Promise<string> {
+  if (task.retry_count >= 1) {
+    throw new Error(`Retry limit reached for task ${task.id}`);
+  }
+
+  const command = task.input_text.trim();
+  if (!isAllowed(command)) {
+    throw new ExecutionBlockedError(`Blocked command: ${command}`);
+  }
+
+  await db.query("BEGIN");
+  try {
+    validateTransition(task.status, "running");
+    const updated = await db.query(`UPDATE hermes_tasks SET status='running', running_since = NOW() WHERE id=$1 AND status=$2`, [task.id, task.status]);
+    if ((updated.rowCount ?? 0) === 0) throw new Error("Race condition entering running state");
+    await logEvent(db, task.id, "execution_started", `Executing command: ${command}`, {});
+    await db.query("COMMIT");
+  } catch (e) {
+    await db.query("ROLLBACK");
+    throw e;
+  }
+
+  try {
+    const output = await runCommandWithTimeout(command, 60_000);
+    const safe = withResultSafety(output);
+    await db.query("BEGIN");
+    try {
+      validateTransition("running", "done");
+      await db.query(`UPDATE hermes_tasks SET status='done', result=$1, result_text=$1 WHERE id=$2 AND status='running'`, [safe.storedResult, task.id]);
+      await logEvent(db, task.id, "execution_finished", "Execution completed", safe.fullOutput ? { full_output: safe.fullOutput } : {});
+      await db.query("COMMIT");
+    } catch (e) {
+      await db.query("ROLLBACK");
+      throw e;
+    }
+    return output;
+  } catch (error) {
+    const normalized = normalizeError(error);
+    const timeout = normalized.message.toLowerCase().includes("timed out");
+    await db.query("BEGIN");
+    try {
+      validateTransition("running", "failed");
+      await db.query(`UPDATE hermes_tasks SET status='failed', retry_count = retry_count + 1, error_text=$1 WHERE id=$2 AND status='running'`, [normalized.message, task.id]);
+      await logEvent(db, task.id, "execution_failed", timeout ? "timeout" : "Execution failed", {
+        reason: timeout ? "timeout" : normalized.message,
+        error: normalized,
+      });
+      await db.query("COMMIT");
+    } catch (e) {
+      await db.query("ROLLBACK");
+      throw e;
+    }
+    throw error;
+  }
+}

--- a/dispatcher/fsm.ts
+++ b/dispatcher/fsm.ts
@@ -1,0 +1,17 @@
+import { TaskStatus } from "./types";
+
+const ALLOWED_TRANSITIONS: Record<TaskStatus, Set<TaskStatus>> = {
+  pending: new Set(["planned"]),
+  planned: new Set(["running", "pending_approval"]),
+  pending_approval: new Set(["approved", "failed"]),
+  approved: new Set(["running"]),
+  running: new Set(["done", "failed"]),
+  done: new Set(),
+  failed: new Set(),
+};
+
+export function validateTransition(currentStatus: TaskStatus, nextStatus: TaskStatus): void {
+  if (!ALLOWED_TRANSITIONS[currentStatus]?.has(nextStatus)) {
+    throw new Error(`Invalid status transition: ${currentStatus} -> ${nextStatus}`);
+  }
+}

--- a/dispatcher/github.ts
+++ b/dispatcher/github.ts
@@ -1,0 +1,22 @@
+import axios from "axios";
+import { Plan, Task } from "./types";
+
+export async function syncGithubComment(task: Task): Promise<void> {
+  if (!task.github_issue_id || task.status !== "done" || !task.plan) return;
+
+  const owner = process.env.GITHUB_OWNER;
+  const repo = process.env.GITHUB_REPO;
+  const token = process.env.GITHUB_TOKEN;
+  if (!owner || !repo || !token) return;
+
+  const plan = task.plan as Plan;
+  const body = `---\n✅ Task completed\n\n**Intent:** ${plan.intent}\n**Risk:** ${plan.risk_level}\n\n**Steps:**\n${plan.steps
+    .map((s, i) => `${i + 1}. ${s}`)
+    .join("\n")}\n\n**Result:** ${task.result ?? task.result_text ?? "(no result)"}\n---`;
+
+  await axios.post(
+    `https://api.github.com/repos/${owner}/${repo}/issues/${task.github_issue_id}/comments`,
+    { body },
+    { headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" } },
+  );
+}

--- a/dispatcher/index.ts
+++ b/dispatcher/index.ts
@@ -1,0 +1,109 @@
+import { pool } from "../db";
+import { requireApprovalIfHighRisk } from "./approval";
+import { normalizeError } from "./errors";
+import { executeTask } from "./executor";
+import { logEvent } from "./events";
+import { validateTransition } from "./fsm";
+import { syncGithubComment } from "./github";
+import { recallMemories } from "./memory";
+import { planTask } from "./planner";
+import { Task } from "./types";
+
+export async function findActiveDuplicateTaskId(inputText: string): Promise<number | null> {
+  const dup = await pool.query(
+    `SELECT id FROM hermes_tasks WHERE input_text = $1 AND status IN ('pending','planned','running') LIMIT 1`,
+    [inputText],
+  );
+  return (dup.rowCount ?? 0) > 0 ? (dup.rows[0].id as number) : null;
+}
+
+
+export async function createTaskOrReuse(taskPayload: { input_text: string; telegram_chat_id: number; telegram_user_id: number }): Promise<number> {
+  await pool.query("BEGIN");
+  try {
+    const existingId = await findActiveDuplicateTaskId(taskPayload.input_text);
+    if (existingId) {
+      await pool.query("COMMIT");
+      return existingId;
+    }
+    const created = await pool.query(
+      `INSERT INTO hermes_tasks (input_text, telegram_chat_id, telegram_user_id, status)
+       VALUES ($1, $2, $3, 'pending') RETURNING id`,
+      [taskPayload.input_text, taskPayload.telegram_chat_id, taskPayload.telegram_user_id],
+    );
+    await pool.query("COMMIT");
+    return created.rows[0].id as number;
+  } catch (error) {
+    await pool.query("ROLLBACK");
+    throw error;
+  }
+}
+async function recoverHungTasks(): Promise<void> {
+  const hung = await pool.query(`SELECT id FROM hermes_tasks WHERE status = 'running' AND running_since < NOW() - INTERVAL '10 minutes'`);
+  for (const row of hung.rows) {
+    await pool.query("BEGIN");
+    try {
+      validateTransition("running", "failed");
+      await pool.query(`UPDATE hermes_tasks SET status='failed' WHERE id=$1 AND status='running'`, [row.id]);
+      await logEvent(pool, row.id, "execution_failed", "hung task recovered", { reason: "hung task recovered" });
+      await pool.query("COMMIT");
+    } catch (error) {
+      await pool.query("ROLLBACK");
+      const normalized = normalizeError(error);
+      await logEvent(pool, row.id, "orchestrator_error", "Hung task recovery failed", { error: normalized });
+      throw error;
+    }
+  }
+}
+
+async function loadTaskForUpdate(taskId: number): Promise<Task | null> {
+  const rs = await pool.query(`SELECT * FROM hermes_tasks WHERE id = $1 FOR UPDATE SKIP LOCKED`, [taskId]);
+  if ((rs.rowCount ?? 0) === 0) return null;
+  return rs.rows[0] as Task;
+}
+
+function memoriesToContext(memories: Record<string, unknown>[]): string {
+  return memories.map((m, i) => `${i + 1}. ${JSON.stringify(m)}`).join("\n");
+}
+
+export async function orchestrateTask(taskId: number): Promise<void> {
+  try {
+    await recoverHungTasks();
+
+    await pool.query("BEGIN");
+    let task = await loadTaskForUpdate(taskId);
+    if (!task) {
+      await pool.query("ROLLBACK");
+      return;
+    }
+    await pool.query("COMMIT");
+
+    if (task.status === "pending") {
+      const memories = await recallMemories(pool, task.id, task.input_text);
+      const plan = await planTask(pool, task, memoriesToContext(memories));
+      if (await requireApprovalIfHighRisk(pool, task.id, plan.risk_level)) return;
+
+      const refreshed = await pool.query(`SELECT * FROM hermes_tasks WHERE id = $1`, [task.id]);
+      task = refreshed.rows[0] as Task;
+      await executeTask(pool, task);
+      return;
+    }
+
+    if (task.status === "approved") {
+      await executeTask(pool, task);
+      return;
+    }
+
+    if (task.status === "pending_approval") {
+      return;
+    }
+
+    if (task.status === "done") {
+      await syncGithubComment(task);
+    }
+  } catch (error) {
+    const normalized = normalizeError(error);
+    await logEvent(pool, taskId, "orchestrator_error", "Orchestration failed", { error: normalized });
+    throw error;
+  }
+}

--- a/dispatcher/memory.ts
+++ b/dispatcher/memory.ts
@@ -1,0 +1,50 @@
+import { logEvent } from "./events";
+import { Memory, Queryable } from "./types";
+
+async function resolveMemoryTextColumn(db: Queryable): Promise<string> {
+  const res = await db.query(
+    `SELECT column_name
+     FROM information_schema.columns
+     WHERE table_name = 'hermes_memories'
+       AND column_name IN ('memory_text', 'content', 'text', 'body')
+     ORDER BY CASE column_name
+       WHEN 'memory_text' THEN 1
+       WHEN 'content' THEN 2
+       WHEN 'text' THEN 3
+       WHEN 'body' THEN 4
+       ELSE 100 END
+     LIMIT 1`,
+  );
+  if ((res.rowCount ?? 0) === 0) {
+    throw new Error("No supported text/content column found in hermes_memories");
+  }
+  return res.rows[0].column_name as string;
+}
+
+async function hasSimilarity(db: Queryable): Promise<boolean> {
+  const res = await db.query(`SELECT EXISTS(SELECT 1 FROM pg_extension WHERE extname='pg_trgm') AS enabled`);
+  return Boolean(res.rows[0]?.enabled);
+}
+
+export async function recallMemories(db: Queryable, taskId: number, taskInputText: string): Promise<Memory[]> {
+  const textCol = await resolveMemoryTextColumn(db);
+  const similarityEnabled = await hasSimilarity(db);
+
+  const sql = similarityEnabled
+    ? `SELECT * FROM hermes_memories
+       WHERE similarity(${textCol}, $1) > 0.3
+       ORDER BY importance DESC NULLS LAST, created_at DESC
+       LIMIT 5`
+    : `SELECT * FROM hermes_memories
+       WHERE ${textCol} ILIKE '%' || $1 || '%'
+       ORDER BY importance DESC NULLS LAST, created_at DESC
+       LIMIT 5`;
+
+  const memories = await db.query(sql, [taskInputText]);
+  await logEvent(db, taskId, "memory_loaded", `Loaded ${memories.rows.length} memories`, {
+    count: memories.rows.length,
+    similarityEnabled,
+    text_column: textCol,
+  });
+  return memories.rows as Memory[];
+}

--- a/dispatcher/planner.ts
+++ b/dispatcher/planner.ts
@@ -1,0 +1,56 @@
+import OpenAI from "openai";
+import { normalizeError } from "./errors";
+import { logEvent } from "./events";
+import { validateTransition } from "./fsm";
+import { Plan, Queryable, Task } from "./types";
+
+const DEPLOYMENT_KEYWORDS = ["git push", "docker", "db write", "migration", "production"];
+const CODE_CHANGE_KEYWORDS = ["refactor", "fix", "implement", "update", "change", "edit", "add", "remove", "code", "typescript", "javascript", "test", "build", "lint", "typecheck"];
+
+function deterministicRisk(input: string): Plan["risk_level"] {
+  const lower = input.toLowerCase();
+  if (DEPLOYMENT_KEYWORDS.some((k) => lower.includes(k))) return "high";
+  if (CODE_CHANGE_KEYWORDS.some((k) => lower.includes(k))) return "medium";
+  return "low";
+}
+
+export async function planTask(db: Queryable, task: Task, memoryContext: string): Promise<Plan> {
+  try {
+    const ai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const prompt = `Task: ${task.input_text}\n\nMemory context:\n${memoryContext || "(none)"}\n\nReturn JSON with keys: intent, read_first, steps, expected_output.`;
+
+    const completion = await ai.chat.completions.create({
+      model: process.env.HERMES_PLANNER_MODEL ?? "gpt-4o-mini",
+      messages: [{ role: "user", content: prompt }],
+      response_format: { type: "json_object" },
+      temperature: 0.2,
+    });
+
+    const parsed = JSON.parse(completion.choices[0]?.message?.content ?? "{}");
+    const plan: Plan = {
+      intent: String(parsed.intent ?? "Execute requested task"),
+      risk_level: deterministicRisk(task.input_text),
+      read_first: Array.isArray(parsed.read_first) ? parsed.read_first.map(String) : [],
+      steps: Array.isArray(parsed.steps) ? parsed.steps.map(String) : [],
+      expected_output: String(parsed.expected_output ?? "Task completed with verifiable output"),
+    };
+
+    await db.query("BEGIN");
+    try {
+      validateTransition(task.status, "planned");
+      const upd = await db.query(`UPDATE hermes_tasks SET plan = $1::jsonb, status = 'planned' WHERE id = $2 AND status = $3`, [JSON.stringify(plan), task.id, task.status]);
+      if ((upd.rowCount ?? 0) === 0) throw new Error("Race condition while setting planned status");
+      await logEvent(db, task.id, "plan_created", "Task plan generated", { risk_level: plan.risk_level });
+      await db.query("COMMIT");
+    } catch (error) {
+      await db.query("ROLLBACK");
+      throw error;
+    }
+
+    return plan;
+  } catch (error) {
+    const normalized = normalizeError(error);
+    await logEvent(db, task.id, "planning_failed", "Planning failed", { error: normalized });
+    throw error;
+  }
+}

--- a/dispatcher/types.ts
+++ b/dispatcher/types.ts
@@ -1,0 +1,38 @@
+export type TaskStatus =
+  | "pending"
+  | "planned"
+  | "pending_approval"
+  | "approved"
+  | "running"
+  | "done"
+  | "failed";
+
+export interface Plan {
+  intent: string;
+  risk_level: "low" | "medium" | "high";
+  read_first: string[];
+  steps: string[];
+  expected_output: string;
+}
+
+export interface Task {
+  id: number;
+  input_text: string;
+  status: TaskStatus;
+  plan: Plan | null;
+  github_issue_id: number | null;
+  retry_count: number;
+  running_since: string | null;
+  result?: string | null;
+  result_text?: string | null;
+}
+
+
+export interface Memory {
+  id: number;
+  [key: string]: unknown;
+}
+
+export interface Queryable {
+  query: (text: string, values?: unknown[]) => Promise<{ rows: any[]; rowCount: number | null }>;
+}


### PR DESCRIPTION
### Motivation
- Provide a centralized orchestration layer to plan, execute, and monitor user-submitted tasks with safety checks and approvals.
- Ensure higher-risk operations require human approval and that all state transitions are validated to avoid invalid or racy updates.
- Improve observability and robustness with structured event logging and normalized error handling.

### Description
- Add core types in `dispatcher/types.ts` and a finite-state machine validator in `dispatcher/fsm.ts` with `validateTransition` to enforce allowed task status changes.
- Implement planning in `dispatcher/planner.ts` that calls the OpenAI API to generate a `Plan`, computes a deterministic risk level, persists the plan, and emits `plan_created` or `planning_failed` events.
- Implement execution in `dispatcher/executor.ts` with command allow-listing, timeout handling, result truncation (`withResultSafety`), retry counting, detailed event logging, and an `ExecutionBlockedError` for disallowed commands.
- Add approval flow in `dispatcher/approval.ts` with `requireApprovalIfHighRisk`, `approveTask`, and `rejectTask` that perform transactional updates and emit corresponding events.
- Add event logging utilities in `dispatcher/events.ts` with idempotent event deduplication for specific event types and JSON metadata support.
- Add memory lookup in `dispatcher/memory.ts` that resolves the best text column, optionally uses `pg_trgm` similarity, loads recent relevant memories, and logs `memory_loaded` events.
- Add GitHub comment synchronization in `dispatcher/github.ts` to post task results to an issue when appropriate using environment credentials.
- Add error normalization in `dispatcher/errors.ts` to convert unknown exceptions into a stable, truncated shape for logging.
- Add `dispatcher/index.ts` orchestrator with `createTaskOrReuse`, `orchestrateTask`, `recoverHungTasks`, locking-backed `loadTaskForUpdate`, memory-to-context serialization, and hooks into planner, approval, executor, and GitHub sync.

### Testing
- Performed a TypeScript type-check with `tsc` to validate types and surface obvious API mismatches, which completed successfully.
- No automated unit or integration tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f256db1c8333a3845b6f1cc2657e)