### PR TITLE
Introduce env/config layer, command & DB guards, and Telegram safety in worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+APP_ENV=development
+TELEGRAM_ENABLED=false
+DEEPSEEK_MODEL=deepseek-chat

--- a/MANUAL_TEST_NOTES.md
+++ b/MANUAL_TEST_NOTES.md
@@ -1,0 +1,27 @@
+# Manual Test Notes
+
+## Scenario 1: Invalid APP_ENV should fail fast
+- Env: `APP_ENV=qa`
+- Expected: process throws on startup with `[env] Invalid APP_ENV` and exits.
+
+## Scenario 2: Development default Telegram OFF
+- Env: `APP_ENV=development`, `TELEGRAM_ENABLED` unset
+- Expected log: `[telegram skipped] env=development reason=env_disabled`
+
+## Scenario 3: Staging explicit Telegram ON
+- Env: `APP_ENV=staging`, `TELEGRAM_ENABLED=true`
+- Expected: Telegram messages are sent (no skip log).
+
+## Scenario 4: Production override Telegram OFF
+- Env: `APP_ENV=production`, `DISABLE_TELEGRAM=true`
+- Expected log: `[telegram skipped] env=production reason=DISABLE_TELEGRAM`
+
+## Scenario 5: Production DB guard reply target required
+- Call: `validateReplyTarget({}, "production")`
+- Expected: throw error JSON with code `INVALID_REPLY_TARGET`.
+
+
+## Scenario 6: Production write/destructive command blocked before execution
+- Env: `APP_ENV=production`
+- Call: shell execution path with `git commit -m "x"` or `git push`
+- Expected: command does **not** run; error includes `requiresApproval=true` and `[command]` reason.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Hermes Agent Platform
+
+## Environment Configuration
+
+Hermes v5 now supports a thin environment-separation config layer via `config/env.js`.
+
+- `APP_ENV` supports: `development`, `staging`, `production`.
+- Startup fails fast when `APP_ENV` is invalid.
+- Telegram behavior is controlled by `effectiveTelegramEnabled`:
+  - `development`: disabled unless `TELEGRAM_ENABLED=true`
+  - `staging`: disabled unless `TELEGRAM_ENABLED=true`
+  - `production`: enabled unless `TELEGRAM_ENABLED=false`
+  - `DISABLE_TELEGRAM=true` always forces Telegram off.
+- Command guard mode is derived from env:
+  - `development` => `safe-block`
+  - `staging` => `approval-required`
+  - `production` => `strict-approval`
+
+### Logging prefixes
+
+The environment guard layer uses consistent prefixes:
+
+- `[env]`
+- `[telegram]`
+- `[command]`
+- `[db guard]`

--- a/config/commandGuard.js
+++ b/config/commandGuard.js
@@ -1,0 +1,66 @@
+const destructivePatterns = [
+  /\bdelete\b/i,
+  /\bdrop\b/i,
+  /\btruncate\b/i,
+  /\bgit\s+push\b/i,
+  /\bdocker\s+rm\b/i,
+  /\bdocker\s+down\b/i,
+];
+
+const writePatterns = [
+  /\binsert\b/i,
+  /\bupdate\b/i,
+  /\bgit\s+commit\b/i,
+];
+
+const readOnlyPatterns = [
+  /^\s*select\b/i,
+  /^\s*get\b/i,
+  /^\s*ls\b/i,
+  /^\s*cat\b/i,
+  /^\s*git\s+status\b/i,
+  /^\s*git\s+log\b/i,
+];
+
+function classifyCommand(cmd = "") {
+  const command = String(cmd).trim();
+
+  if (destructivePatterns.some((p) => p.test(command))) return "destructive";
+  if (writePatterns.some((p) => p.test(command))) return "write";
+  if (readOnlyPatterns.some((p) => p.test(command))) return "read-only";
+  return "unknown";
+}
+
+function checkCommand(cmd, env = "development") {
+  const kind = classifyCommand(cmd);
+
+  if (env === "development") {
+    if (kind === "destructive") {
+      return { allowed: false, requiresApproval: false, reason: "[command] destructive_blocked_development" };
+    }
+    return { allowed: true, requiresApproval: false, reason: `[command] allowed_${kind}` };
+  }
+
+  if (env === "staging") {
+    if (kind === "destructive") {
+      return { allowed: true, requiresApproval: true, reason: "[command] destructive_requires_approval_staging" };
+    }
+    return { allowed: true, requiresApproval: false, reason: `[command] allowed_${kind}` };
+  }
+
+  if (env === "production") {
+    if (kind === "read-only") {
+      return { allowed: true, requiresApproval: false, reason: "[command] read_only_allowed_production" };
+    }
+
+    if (kind === "write" || kind === "destructive") {
+      return { allowed: true, requiresApproval: true, reason: `[command] ${kind}_requires_approval_production` };
+    }
+
+    return { allowed: false, requiresApproval: false, reason: "[command] unknown_blocked_production" };
+  }
+
+  return { allowed: false, requiresApproval: false, reason: "[command] invalid_env" };
+}
+
+module.exports = { checkCommand };

--- a/config/dbGuard.js
+++ b/config/dbGuard.js
@@ -1,0 +1,16 @@
+function validateReplyTarget({ telegram_chat_id, telegram_user_id } = {}, env = "development") {
+  if (env !== "production") return true;
+
+  if (!telegram_chat_id || !telegram_user_id) {
+    throw new Error(
+      JSON.stringify({
+        code: "INVALID_REPLY_TARGET",
+        message: "telegram_chat_id and telegram_user_id required in production",
+      })
+    );
+  }
+
+  return true;
+}
+
+module.exports = { validateReplyTarget };

--- a/config/env.js
+++ b/config/env.js
@@ -1,0 +1,52 @@
+const path = require("path");
+
+const VALID_ENVS = ["development", "staging", "production"];
+const APP_ENV = process.env.APP_ENV || "development";
+
+if (!VALID_ENVS.includes(APP_ENV)) {
+  throw new Error(`[env] Invalid APP_ENV: ${APP_ENV}. Valid values: ${VALID_ENVS.join(", ")}`);
+}
+
+function isTrue(value) {
+  return String(value).toLowerCase() === "true";
+}
+
+function isFalse(value) {
+  return String(value).toLowerCase() === "false";
+}
+
+function resolveTelegramEnabled() {
+  if (isTrue(process.env.DISABLE_TELEGRAM)) return false;
+
+  if (APP_ENV === "production") {
+    return !isFalse(process.env.TELEGRAM_ENABLED);
+  }
+
+  return isTrue(process.env.TELEGRAM_ENABLED);
+}
+
+const effectiveTelegramEnabled = resolveTelegramEnabled();
+
+const COMMAND_MODE_BY_ENV = {
+  development: "safe-block",
+  staging: "approval-required",
+  production: "strict-approval",
+};
+
+const commandMode = COMMAND_MODE_BY_ENV[APP_ENV];
+const projectRoot = process.env.PROJECT_ROOT || "/root/projects/somewhere-sanctuary-hub-main-final";
+
+function logStartupConfig() {
+  console.log(`[env] APP_ENV=${APP_ENV}`);
+  console.log(`[env] commandMode=${commandMode}`);
+  console.log(`[env] effectiveTelegramEnabled=${effectiveTelegramEnabled}`);
+  console.log(`[env] projectRoot=${path.resolve(projectRoot)}`);
+}
+
+module.exports = {
+  APP_ENV,
+  effectiveTelegramEnabled,
+  commandMode,
+  projectRoot,
+  logStartupConfig,
+};

--- a/worker.js
+++ b/worker.js
@@ -5,20 +5,52 @@ const { promisify } = require("util");
 const fs = require("fs");
 const path = require("path");
 const { query } = require("./db");
+const envConfig = require("./config/env");
+const { checkCommand } = require("./config/commandGuard");
+const { validateReplyTarget } = require("./config/dbGuard");
 
-const execAsync = promisify(exec);
+const rawExecAsync = promisify(exec);
+
+async function execAsync(command, options = {}) {
+  const decision = checkCommand(command, envConfig.APP_ENV);
+
+  if (!decision.allowed) {
+    throw new Error(`[command] blocked reason=${decision.reason}`);
+  }
+
+  if (decision.requiresApproval) {
+    throw new Error(`[command] blocked reason=${decision.reason} requiresApproval=true`);
+  }
+
+  return rawExecAsync(command, options);
+}
 
 const TELEGRAM_TOKEN = process.env.TELEGRAM_TOKEN;
 const TELEGRAM_API = `https://api.telegram.org/bot${TELEGRAM_TOKEN}`;
 
-const PROJECT_ROOT = "/root/projects/somewhere-sanctuary-hub-main-final";
+const PROJECT_ROOT = envConfig.projectRoot;
 
 const ai = new OpenAI({
   apiKey: process.env.DEEPSEEK_API_KEY,
   baseURL: "https://api.deepseek.com",
 });
 
-async function sendTelegramMessage(chatId, text, buttons = null) {
+async function sendTelegramMessage(chatId, text, buttons = null, telegramUserId = null) {
+  if (process.env.DISABLE_TELEGRAM === "true") {
+    console.log("[telegram skipped] env=%s reason=DISABLE_TELEGRAM", envConfig.APP_ENV);
+    return;
+  }
+
+  if (!envConfig.effectiveTelegramEnabled) {
+    console.log("[telegram skipped] env=%s reason=env_disabled", envConfig.APP_ENV);
+    return;
+  }
+
+  validateReplyTarget({
+    telegram_chat_id: chatId,
+    telegram_user_id: telegramUserId,
+  }, envConfig.APP_ENV);
+
   const MAX = 3500;
   const chunks = String(text).match(new RegExp(`[\\s\\S]{1,${MAX}}`, "g")) || [""];
 
@@ -87,7 +119,6 @@ function assertCanEditFile(filePath) {
     throw new Error(`File được bảo vệ, không cho Hermes sửa: ${filePath}`);
   }
 }
-
 
 function shouldRunBuildForFile(filePath) {
   const normalized = filePath.replace(/\\/g, "/");
@@ -227,11 +258,12 @@ async function runSafeCommand(taskId, command) {
     await event(taskId, 'approval_requested', `Risky command requires approval: ${command}`, { command });
 
   const taskRow = await query(
-  `select telegram_chat_id from hermes_tasks where id=$1`,
+  `select telegram_chat_id, telegram_user_id from hermes_tasks where id=$1`,
   [taskId]
 );
 
 const chatId = taskRow.rows[0]?.telegram_chat_id;
+const telegramUserId = taskRow.rows[0]?.telegram_user_id;
 
 if (chatId) {
   await sendTelegramMessage(
@@ -243,6 +275,7 @@ if (chatId) {
         { text: "❌ Từ chối", callback_data: `reject_${taskId}` },
       ],
     ]
+    , telegramUserId
   );
 }
 
@@ -260,8 +293,6 @@ return "Đang chờ bạn duyệt...";
 
   return [stdout, stderr].filter(Boolean).join("\n") || "Lệnh chạy xong, không có output.";
 }
-
-
 
 async function classifyIntent(text) {
   const intent = detectIntent(text);
@@ -437,7 +468,6 @@ const aiRes = await ai.chat.completions.create({
 
   return `Patch #${id} (${r.rows[0].file_path}):\n\n${r.rows[0].diff_text.slice(0, 3500)}`;
 }
-
 
 if (intent === "approve_patch") {
   const m = text.match(/\d+/);
@@ -675,11 +705,7 @@ return [
   return `Hermes đã ghi nhớ: ${memoryText}`;
 }
 
-
   const isAudit = text.toLowerCase().includes("audit")    || text.toLowerCase().includes("đánh giá")    || text.toLowerCase().includes("phân tích");  const isExecute = text.toLowerCase().includes("fix")   || text.toLowerCase().includes("sửa")   || text.toLowerCase().includes("build");  const isComplex = isAudit || isExecute;
-
-
-
 
   if (intent === "repo_status") {
     if (!fs.existsSync(PROJECT_ROOT)) {
@@ -694,7 +720,6 @@ return [
 
     return `Repo root:\n${PROJECT_ROOT}\n\nFiles:\n${files || "(trống)"}`;
   }
-
 
   if (intent === "branch_status") {
     const current = await execAsync(`git branch --show-current`, {
@@ -743,7 +768,6 @@ return [
     await logAction(task.id, "run_command", { command }, { output }, "success");
     return output;
   }
-
 
   if (intent === "rollback_patch") {
     const m = text.match(/\d+/);
@@ -917,7 +941,6 @@ const output = [stdout, stderr].filter(Boolean).join("\n") || "Lệnh chạy xon
   }
 }  
 
-
   if (intent === "reject_task") {
     const match = text.match(/\d+/);
     if (!match) return "Bạn cần nói: từ chối task 12";
@@ -956,7 +979,6 @@ Lệnh không được chạy:
 ${approval.command}`;
   }
 
-
   const memories = await loadMemories();
   const useMemory = intent === "learn" || intent === "recall_memory";
 
@@ -976,8 +998,6 @@ Detected Hermes system:
 - gbrain.js stores and retrieves memories.
 - docker-compose.yml runs app, worker, and db services.
 `;
-
-
 
   const response = await ai.chat.completions.create({
     model: process.env.DEEPSEEK_MODEL || "deepseek-chat",
@@ -1072,7 +1092,10 @@ async function processOneTask() {
     );
 
     await event(task.id, "completed", "Task completed");
-    await sendTelegramMessage(task.telegram_chat_id, `Task #${task.id} hoàn tất:\n\n${output}`);
+    await sendTelegramMessage(task.telegram_chat_id, `Task #${task.id} hoàn tất:
+
+${output}`, null, task.telegram_user_id);
+
   } catch (err) {
     const errorText = err.response?.data ? JSON.stringify(err.response.data) : err.message;
 
@@ -1082,7 +1105,9 @@ async function processOneTask() {
     );
 
     await event(task.id, "failed", errorText);
-    await sendTelegramMessage(task.telegram_chat_id, `Task #${task.id} bị lỗi:\n${errorText}`);
+    await sendTelegramMessage(task.telegram_chat_id, `Task #${task.id} bị lỗi:
+${errorText}`, null, task.telegram_user_id);
+
   }
 }
 
@@ -1096,5 +1121,6 @@ async function loop() {
   setTimeout(loop, 2000);
 }
 
+envConfig.logStartupConfig();
 console.log("Hermes Dev Agent worker started");
 loop();


### PR DESCRIPTION
### Motivation

- Provide a thin environment separation layer to enforce runtime behavior via `APP_ENV` and to centralize env-derived settings like `effectiveTelegramEnabled` and `commandMode`.
- Harden command execution with an allowlist/approval model to prevent accidental destructive or write operations in non-development environments.
- Require explicit reply targets and allow toggling Telegram delivery to avoid accidental messages from the agent in staging/production.

### Description

- Add `config/env.js` to validate `APP_ENV`, compute `effectiveTelegramEnabled`, expose `commandMode` and `projectRoot`, and log startup config, and add `.env.example` demonstrating keys `APP_ENV`, `TELEGRAM_ENABLED`, and `DEEPSEEK_MODEL`.
- Add `config/commandGuard.js` providing `classifyCommand` and `checkCommand` with distinct behaviors for `development`, `staging`, and `production` (safe-block / approval-required / strict-approval modes).
- Add `config/dbGuard.js` with `validateReplyTarget` that throws `INVALID_REPLY_TARGET` when reply targets are missing in `production`.
- Update `worker.js` to integrate the new config: replace direct `exec` usage with an `execAsync` wrapper that consults `checkCommand`, wire `PROJECT_ROOT` to `envConfig.projectRoot`, and call `envConfig.logStartupConfig()` on startup.
- Enhance Telegram sending flow in `worker.js` to respect `DISABLE_TELEGRAM` and `effectiveTelegramEnabled`, validate reply targets via `validateReplyTarget`, propagate `telegram_user_id` when looking up tasks, and include `telegram_user_id` in send calls.
- Add `README.md` documenting environment behavior and guard modes and `MANUAL_TEST_NOTES.md` with manual scenarios for env and guard behavior.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f307df888c8333af3690be20f580de)