### PR TITLE
Add advanced dispatcher subsystems (queue, approvals, idempotency, monitoring, planning, GitHub PRs) and env/schema updates

### DIFF
--- a/MANUAL_TEST_NOTES.md
+++ b/MANUAL_TEST_NOTES.md
@@ -1,27 +1,46 @@
-# Manual Test Notes
+# Manual Test Notes (Queue + Approval + Idempotency + PR Agent)
 
-## Scenario 1: Invalid APP_ENV should fail fast
-- Env: `APP_ENV=qa`
-- Expected: process throws on startup with `[env] Invalid APP_ENV` and exits.
+## 1) Two-worker claim race
+1. Insert 1 `pending` task.
+2. Run two worker processes with different `HERMES_WORKER_ID`.
+3. Verify only one worker updates task to `running` with `locked_by` set.
+4. Verify second worker does not process same task.
 
-## Scenario 2: Development default Telegram OFF
-- Env: `APP_ENV=development`, `TELEGRAM_ENABLED` unset
-- Expected log: `[telegram skipped] env=development reason=env_disabled`
+## 2) Stale task recovery
+1. Set a task to `running` with `heartbeat_at = now() - interval '11 minutes'`.
+2. Call `recoverStaleTasks()`.
+3. If `retry_count < max_retries`, verify task returns to `pending` and `retry_count` increments.
+4. If `retry_count >= max_retries`, verify task becomes `failed`.
 
-## Scenario 3: Staging explicit Telegram ON
-- Env: `APP_ENV=staging`, `TELEGRAM_ENABLED=true`
-- Expected: Telegram messages are sent (no skip log).
+## 3) retry_count behavior
+1. Force transient failure path via `failTask(taskId, workerId, err, true)`.
+2. Verify only retryable failures increment `retry_count`.
+3. Verify permanent failure path marks `failed` without extra retries.
 
-## Scenario 4: Production override Telegram OFF
-- Env: `APP_ENV=production`, `DISABLE_TELEGRAM=true`
-- Expected log: `[telegram skipped] env=production reason=DISABLE_TELEGRAM`
+## 4) Approval payload hash mismatch
+1. Create approval for payload A.
+2. Try consume with payload B.
+3. Verify consume returns false and action not executed.
 
-## Scenario 5: Production DB guard reply target required
-- Call: `validateReplyTarget({}, "production")`
-- Expected: throw error JSON with code `INVALID_REPLY_TARGET`.
+## 5) Approval consume once
+1. Approve token and consume once.
+2. Consume again with same token/payload.
+3. Verify second consume is no-op (false).
 
+## 6) Idempotent PR creation
+1. Run `createPullRequest` twice with same idempotency key inputs.
+2. Verify second call returns stored result, no second PR.
 
-## Scenario 6: Production write/destructive command blocked before execution
-- Env: `APP_ENV=production`
-- Call: shell execution path with `git commit -m "x"` or `git push`
-- Expected: command does **not** run; error includes `requiresApproval=true` and `[command]` reason.
+## 7) Push requires approval
+1. Attempt `git push` through worker command path in prod.
+2. Verify blocked/approval-required behavior before execution.
+
+## 8) Gate failed PR body
+1. Force gate failure.
+2. Create PR.
+3. Verify PR body includes `PATCH DONE BUT GATE FAILED`.
+
+## 9) waiting_approval not auto-picked
+1. Set task status `waiting_approval`.
+2. Run claim loop.
+3. Verify `claimNextTask` does not pick the task.

--- a/config/env.js
+++ b/config/env.js
@@ -1,52 +1,39 @@
-const path = require("path");
+const path = require('path');
 
-const VALID_ENVS = ["development", "staging", "production"];
-const APP_ENV = process.env.APP_ENV || "development";
-
-if (!VALID_ENVS.includes(APP_ENV)) {
-  throw new Error(`[env] Invalid APP_ENV: ${APP_ENV}. Valid values: ${VALID_ENVS.join(", ")}`);
+const HERMES_ENV = (process.env.HERMES_ENV || 'dev').toLowerCase();
+if (!['dev', 'prod'].includes(HERMES_ENV)) {
+  throw new Error(`[env] Invalid HERMES_ENV=${HERMES_ENV}. Use dev|prod`);
 }
 
-function isTrue(value) {
-  return String(value).toLowerCase() === "true";
+const projectRootDev = process.env.PROJECT_ROOT_DEV || process.env.PROJECT_ROOT || process.cwd();
+const projectRootProd = process.env.PROJECT_ROOT_PROD || process.env.PROJECT_ROOT || process.cwd();
+
+const projectRoot = path.resolve(HERMES_ENV === 'prod' ? projectRootProd : projectRootDev);
+const prodRoot = path.resolve(projectRootProd);
+
+if (HERMES_ENV === 'dev' && projectRoot === prodRoot) {
+  throw new Error('[env] dev mode cannot target PROJECT_ROOT_PROD');
 }
 
-function isFalse(value) {
-  return String(value).toLowerCase() === "false";
-}
+const telegramToken = HERMES_ENV === 'prod'
+  ? (process.env.TELEGRAM_BOT_TOKEN_PROD || process.env.TELEGRAM_TOKEN)
+  : (process.env.TELEGRAM_BOT_TOKEN_DEV || process.env.TELEGRAM_TOKEN);
 
-function resolveTelegramEnabled() {
-  if (isTrue(process.env.DISABLE_TELEGRAM)) return false;
-
-  if (APP_ENV === "production") {
-    return !isFalse(process.env.TELEGRAM_ENABLED);
-  }
-
-  return isTrue(process.env.TELEGRAM_ENABLED);
-}
-
-const effectiveTelegramEnabled = resolveTelegramEnabled();
-
-const COMMAND_MODE_BY_ENV = {
-  development: "safe-block",
-  staging: "approval-required",
-  production: "strict-approval",
-};
-
-const commandMode = COMMAND_MODE_BY_ENV[APP_ENV];
-const projectRoot = process.env.PROJECT_ROOT || "/root/projects/somewhere-sanctuary-hub-main-final";
+const APP_ENV = HERMES_ENV === 'prod' ? 'production' : 'development';
 
 function logStartupConfig() {
+  console.log(`[env] HERMES_ENV=${HERMES_ENV}`);
   console.log(`[env] APP_ENV=${APP_ENV}`);
-  console.log(`[env] commandMode=${commandMode}`);
-  console.log(`[env] effectiveTelegramEnabled=${effectiveTelegramEnabled}`);
-  console.log(`[env] projectRoot=${path.resolve(projectRoot)}`);
+  console.log(`[env] projectRoot=${projectRoot}`);
 }
 
 module.exports = {
+  HERMES_ENV,
   APP_ENV,
-  effectiveTelegramEnabled,
-  commandMode,
   projectRoot,
+  projectRootDev: path.resolve(projectRootDev),
+  projectRootProd: prodRoot,
+  TELEGRAM_TOKEN: telegramToken,
+  effectiveTelegramEnabled: process.env.DISABLE_TELEGRAM !== 'true',
   logStartupConfig,
 };

--- a/dispatcher/alert.js
+++ b/dispatcher/alert.js
@@ -1,0 +1,40 @@
+const axios = require('axios');
+const { query } = require('../db');
+
+const lastAlertAt = new Map();
+const ALERT_INTERVAL_MS = 5 * 60 * 1000;
+
+function sanitize(payload = {}) {
+  const out = {};
+  for (const [k, v] of Object.entries(payload || {})) {
+    if (/token|key|secret|password/i.test(k)) continue;
+    out[k] = typeof v === 'string' ? v.slice(0, 500) : v;
+  }
+  return out;
+}
+
+async function triggerAlert(type, payload = {}) {
+  const now = Date.now();
+  const last = lastAlertAt.get(type) || 0;
+  if (now - last < ALERT_INTERVAL_MS) return { skipped: true, reason: 'rate_limited' };
+  lastAlertAt.set(type, now);
+
+  const safePayload = sanitize(payload);
+  await query(
+    `insert into hermes_action_logs (task_id, action_name, input, output, status)
+     values ($1,$2,$3,$4,$5)`,
+    [safePayload.task_id || null, 'alert', { type }, safePayload, 'alerted'],
+  );
+
+  if (process.env.TELEGRAM_TOKEN && process.env.OWNER_CHAT_ID) {
+    const text = `⚠️ Hermes Alert: ${type}\n${JSON.stringify(safePayload).slice(0, 1200)}`;
+    await axios.post(`https://api.telegram.org/bot${process.env.TELEGRAM_TOKEN}/sendMessage`, {
+      chat_id: process.env.OWNER_CHAT_ID,
+      text,
+    });
+  }
+
+  return { sent: true };
+}
+
+module.exports = { triggerAlert };

--- a/dispatcher/approval.ts
+++ b/dispatcher/approval.ts
@@ -1,50 +1,78 @@
-import { logEvent } from "./events";
-import { validateTransition } from "./fsm";
-import { Queryable, TaskStatus } from "./types";
+import * as crypto from 'crypto';
+import { logEvent } from './events';
+import { validateTransition } from './fsm';
+import { Queryable, TaskStatus } from './types';
+
+function hashPayload(payload: unknown): string {
+  return crypto.createHash('sha256').update(JSON.stringify(payload || {})).digest('hex');
+}
 
 async function updateStatusTx(db: Queryable, taskId: number, from: TaskStatus, to: TaskStatus): Promise<void> {
   validateTransition(from, to);
-  const res = await db.query(
-    `UPDATE hermes_tasks SET status = $1 WHERE id = $2 AND status = $3`,
-    [to, taskId, from],
-  );
+  const res = await db.query(`UPDATE hermes_tasks SET status = $1 WHERE id = $2 AND status = $3`, [to, taskId, from]);
   if ((res.rowCount ?? 0) === 0) throw new Error(`Race condition updating task ${taskId} ${from} -> ${to}`);
 }
 
+export async function createCommandApproval(db: Queryable, taskId: number, actionType: string, riskLevel: string, payload: unknown = {}): Promise<string> {
+  const token = crypto.randomBytes(16).toString('hex');
+  const payloadHash = hashPayload(payload);
+  await db.query(
+    `insert into hermes_approvals (task_id,status,action_type,risk_level,approval_token,expires_at,payload_hash)
+     values ($1,'pending',$2,$3,$4, now() + interval '30 minutes',$5)`,
+    [taskId, actionType, riskLevel, token, payloadHash],
+  );
+  await logEvent(db, taskId, 'approval_required', `Approval required for ${actionType}`, { riskLevel });
+  return token;
+}
+
+export async function consumeApprovalToken(db: Queryable, taskId: number, token: string, payload: unknown = {}, executedBy = 'system', idempotencyKey: string | null = null): Promise<boolean> {
+  const payloadHash = hashPayload(payload);
+  const res = await db.query(
+    `update hermes_approvals set status='executed', executed_at=now(), executed_by=$4, idempotency_key=coalesce($5,idempotency_key)
+     where task_id=$1 and approval_token=$2 and status='approved' and expires_at > now()
+       and executed_at is null and payload_hash=$3`,
+    [taskId, token, payloadHash, executedBy, idempotencyKey],
+  );
+  if ((res.rowCount ?? 0) === 1) await logEvent(db, taskId, 'approval_executed', 'Approved action executed', { token });
+  return (res.rowCount ?? 0) === 1;
+}
+
 export async function approveTask(db: Queryable, taskId: number): Promise<void> {
-  await db.query("BEGIN");
+  await db.query('BEGIN');
   try {
-    await updateStatusTx(db, taskId, "pending_approval", "approved");
-    await logEvent(db, taskId, "approved", "Task approved", {});
-    await db.query("COMMIT");
+    await updateStatusTx(db, taskId, 'pending_approval', 'approved');
+    await db.query(`update hermes_approvals set status='approved' where task_id=$1 and status='pending'`, [taskId]);
+    await logEvent(db, taskId, 'approved', 'Task approved', {});
+    await db.query('COMMIT');
   } catch (error) {
-    await db.query("ROLLBACK");
+    await db.query('ROLLBACK');
     throw error;
   }
 }
 
 export async function rejectTask(db: Queryable, taskId: number): Promise<void> {
-  await db.query("BEGIN");
+  await db.query('BEGIN');
   try {
-    await updateStatusTx(db, taskId, "pending_approval", "failed");
-    await logEvent(db, taskId, "rejected", "Task rejected", {});
-    await db.query("COMMIT");
+    await updateStatusTx(db, taskId, 'pending_approval', 'failed');
+    await db.query(`update hermes_approvals set status='rejected' where task_id=$1 and status='pending'`, [taskId]);
+    await logEvent(db, taskId, 'rejected', 'Task rejected', {});
+    await db.query('COMMIT');
   } catch (error) {
-    await db.query("ROLLBACK");
+    await db.query('ROLLBACK');
     throw error;
   }
 }
 
 export async function requireApprovalIfHighRisk(db: Queryable, taskId: number, riskLevel: string): Promise<boolean> {
-  if (riskLevel !== "high") return false;
-  await db.query("BEGIN");
+  if (riskLevel !== 'high') return false;
+  await db.query('BEGIN');
   try {
-    await updateStatusTx(db, taskId, "planned", "pending_approval");
-    await logEvent(db, taskId, "approval_required", "High-risk task requires approval", {});
-    await db.query("COMMIT");
+    await updateStatusTx(db, taskId, 'planned', 'pending_approval');
+    await logEvent(db, taskId, 'approval_required', 'High-risk task requires approval', {});
+    await db.query('COMMIT');
     return true;
   } catch (error) {
-    await db.query("ROLLBACK");
+    await db.query('ROLLBACK');
     throw error;
   }
 }

--- a/dispatcher/autodebug.js
+++ b/dispatcher/autodebug.js
@@ -1,0 +1,88 @@
+const { query } = require('../db');
+const { classifyError } = require('./errorClassifier');
+const { runGate } = require('./gate');
+const { startIdempotentAction, completeIdempotentAction, failIdempotentAction } = require('./idempotency');
+const { updateSession } = require('./session');
+
+function shortError(text) {
+  return String(text || '').split('\n').slice(0, 2).join(' ').slice(0, 180);
+}
+
+async function recallBugHistory(errorText) {
+  const pattern = `%${shortError(errorText).split(' ')[0] || 'error'}%`;
+  const res = await query(
+    `select memory_text from hermes_memories where memory_type='bug_history'
+     and memory_text ilike $1 order by updated_at desc limit 3`,
+    [pattern],
+  );
+  return res.rows.map((r) => r.memory_text);
+}
+
+async function storeBugMemory(taskId, errorText, fixSummary) {
+  await query(
+    `insert into hermes_memories (memory_key,memory_text,memory_type,importance,confidence,last_used_at)
+     values ($1,$2,'bug_history',4,0.7,now())`,
+    [`bug:${taskId}`, JSON.stringify({ error_pattern: shortError(errorText), fix_summary: fixSummary })],
+  );
+}
+
+async function handleTaskFailure(task, session, error, context = {}) {
+  const errorText = String(error || 'unknown');
+  const classified = classifyError(errorText);
+  await updateSession(task.id, { last_error_type: classified.type, last_error: shortError(errorText) });
+
+  if (classified.type === 'TRANSIENT') {
+    return { handled: false, retryable: true, error_type: classified.type, auto_fix: false };
+  }
+  if (classified.type === 'ENV') {
+    return { handled: true, retryable: false, error_type: classified.type, auto_fix: false };
+  }
+
+  let attempts = Number(session?.debug_attempts || 0);
+  if (classified.type === 'UNKNOWN' && attempts >= 1) {
+    return { handled: true, retryable: false, error_type: classified.type, auto_fix: false };
+  }
+  if (classified.type === 'CODE' && attempts >= 2) {
+    return { handled: true, retryable: false, error_type: classified.type, auto_fix: false };
+  }
+
+  attempts += 1;
+  await updateSession(task.id, { debug_attempts: attempts });
+  const idemKey = `${task.id}:debug:${attempts}`;
+  const start = await startIdempotentAction(idemKey, task.id, 'autodebug', { error: shortError(errorText), attempt: attempts });
+  if (start.state !== 'started') {
+    return { handled: true, retryable: false, error_type: classified.type, auto_fix: false, debug_attempts: attempts };
+  }
+
+  const memoryHints = await recallBugHistory(errorText);
+  try {
+    if (context.onFirstDebugAttempt && attempts === 1) {
+      await context.onFirstDebugAttempt(`🛠️ Hermes auto-debug attempt #1 for task #${task.id}`);
+    }
+
+    // Reuse existing gate flow; no dangerous command execution.
+    const gateResult = await Promise.race([
+      runGate(context.projectRoot),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('autodebug_timeout')), 90000)),
+    ]);
+
+    const passed = gateResult.status === 'PATCH DONE AND GATE PASSED';
+    await completeIdempotentAction(idemKey, { gate: gateResult.status, memoryHints: memoryHints.slice(0, 2) });
+    await storeBugMemory(task.id, errorText, passed ? 'gate passed after safe retry' : 'gate still failing');
+
+    return {
+      handled: true,
+      retryable: !passed && attempts < (classified.type === 'CODE' ? 2 : 1),
+      error_type: classified.type,
+      debug_attempts: attempts,
+      auto_fix: passed,
+      gate_status: gateResult.status,
+      memory_hints_used: memoryHints.slice(0, 2),
+    };
+  } catch (e) {
+    await failIdempotentAction(idemKey, e.message);
+    return { handled: true, retryable: attempts < 2, error_type: classified.type, debug_attempts: attempts, auto_fix: false };
+  }
+}
+
+module.exports = { handleTaskFailure };

--- a/dispatcher/automation.js
+++ b/dispatcher/automation.js
@@ -1,0 +1,50 @@
+const axios = require('axios');
+const { query } = require('../db');
+
+const ALLOWED = new Set(['notify_if_failed_tasks', 'notify_if_stuck_tasks', 'run_daily_report', 'simple_webhook_call']);
+
+function validateConfig(config = {}) {
+  if (!ALLOWED.has(config.action)) throw new Error('invalid_action');
+  if (config.action === 'simple_webhook_call' && !config.webhook_url) throw new Error('missing_webhook_url');
+}
+
+async function executeAutomation(config = {}) {
+  validateConfig(config);
+  const dryRun = config.dry_run === true;
+  let sideEffectCount = 0;
+
+  const runner = async () => {
+    if (config.action === 'notify_if_failed_tasks') {
+      const r = await query(`select count(*)::int as c from hermes_tasks where status='failed' and updated_at > now() - interval '1 hour'`);
+      if (!dryRun && Number(r.rows[0]?.c || 0) > 0 && process.env.TELEGRAM_TOKEN && process.env.OWNER_CHAT_ID && sideEffectCount < 1) {
+        sideEffectCount += 1;
+        await axios.post(`https://api.telegram.org/bot${process.env.TELEGRAM_TOKEN}/sendMessage`, { chat_id: process.env.OWNER_CHAT_ID, text: `Hermes: failed tasks last hour=${r.rows[0].c}` });
+      }
+      return { action: config.action, failed_count: Number(r.rows[0]?.c || 0), dry_run: dryRun };
+    }
+
+    if (config.action === 'notify_if_stuck_tasks') {
+      const r = await query(`select count(*)::int as c from hermes_tasks where status='running' and heartbeat_at < now() - interval '10 minutes'`);
+      return { action: config.action, stuck_count: Number(r.rows[0]?.c || 0), dry_run: dryRun };
+    }
+
+    if (config.action === 'run_daily_report') {
+      const r = await query(`select count(*)::int as c from hermes_tasks where created_at > now() - interval '1 day'`);
+      return { action: config.action, daily_tasks: Number(r.rows[0]?.c || 0), dry_run: dryRun };
+    }
+
+    if (config.action === 'simple_webhook_call') {
+      if (!dryRun && sideEffectCount < 1) {
+        sideEffectCount += 1;
+        await axios.post(config.webhook_url, config.payload || {});
+      }
+      return { action: config.action, webhook_called: !dryRun, dry_run: dryRun };
+    }
+
+    throw new Error('unsupported_action');
+  };
+
+  return Promise.race([runner(), new Promise((_, reject) => setTimeout(() => reject(new Error('automation_timeout')), 15000))]);
+}
+
+module.exports = { executeAutomation, validateConfig };

--- a/dispatcher/errorClassifier.js
+++ b/dispatcher/errorClassifier.js
@@ -1,0 +1,39 @@
+function classifyError(errorText = '') {
+  const t = String(errorText || '').toLowerCase();
+
+  if (
+    t.includes('etimedout') ||
+    t.includes('timeout') ||
+    t.includes('econnreset') ||
+    t.includes('connection reset') ||
+    t.includes('network error') ||
+    t.includes('socket hang up')
+  ) {
+    return { type: 'TRANSIENT', retryable: true };
+  }
+
+  if (
+    t.includes('syntaxerror') ||
+    t.includes('typeerror') ||
+    t.includes('referenceerror') ||
+    t.includes('npm run build') ||
+    t.includes('build failed') ||
+    t.includes('test failed') ||
+    t.includes('lint failed')
+  ) {
+    return { type: 'CODE', retryable: false };
+  }
+
+  if (
+    t.includes('missing env') ||
+    t.includes('missing') && t.includes('env') ||
+    t.includes('invalid app_env') ||
+    t.includes('config error')
+  ) {
+    return { type: 'ENV', retryable: false };
+  }
+
+  return { type: 'UNKNOWN', retryable: true };
+}
+
+module.exports = { classifyError };

--- a/dispatcher/gate.js
+++ b/dispatcher/gate.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+const { exec } = require('child_process');
+const { promisify } = require('util');
+const execAsync = promisify(exec);
+
+async function runGate(projectRoot) {
+  const pkgPath = path.join(projectRoot, 'package.json');
+  if (!fs.existsSync(pkgPath)) return { status: 'passed', checks: [] };
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  const scripts = pkg.scripts || {};
+
+  const checks = [
+    ['lint', 'npm run lint'],
+    ['typecheck', 'npm run typecheck'],
+    ['test', 'npm run test'],
+    ['build', 'npm run build'],
+  ];
+
+  const results = [];
+  for (const [name, cmd] of checks) {
+    if (!scripts[name] && !(name === 'test' && scripts.test) && !(name === 'build' && scripts.build)) {
+      results.push({ name, status: 'skipped' });
+      continue;
+    }
+    try {
+      await execAsync(cmd, { cwd: projectRoot, shell: '/bin/bash', timeout: 600000, maxBuffer: 1024 * 1024 * 8 });
+      results.push({ name, status: 'passed' });
+    } catch (e) {
+      results.push({ name, status: 'failed', error: e.stderr || e.stdout || e.message });
+    }
+  }
+
+  const failed = results.some((r) => r.status === 'failed');
+  return { status: failed ? 'PATCH DONE BUT GATE FAILED' : 'PATCH DONE AND GATE PASSED', checks: results };
+}
+
+module.exports = { runGate };

--- a/dispatcher/github.js
+++ b/dispatcher/github.js
@@ -1,0 +1,90 @@
+const axios = require('axios');
+const { exec } = require('child_process');
+const { promisify } = require('util');
+const { startIdempotentAction, completeIdempotentAction, failIdempotentAction } = require('./idempotency');
+const { updateSession } = require('./session');
+
+const execAsync = promisify(exec);
+
+function getGithubConfig() {
+  return {
+    token: process.env.GITHUB_TOKEN,
+    owner: process.env.GITHUB_OWNER,
+    repo: process.env.GITHUB_REPO,
+    base: process.env.GITHUB_DEFAULT_BASE || 'main',
+  };
+}
+
+function createBranchName(task) {
+  const slug = String(task.input_text || 'task').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 32) || 'task';
+  return `hermes/task-${task.id}-${slug}`;
+}
+
+async function createIssueFromTask(task, session) {
+  const cfg = getGithubConfig();
+  if (!cfg.token || !cfg.owner || !cfg.repo) return null;
+  const idemKey = `issue:${task.id}`;
+  const start = await startIdempotentAction(idemKey, task.id, 'create_issue', { title: task.input_text });
+  if (start.state === 'completed') return start.existing.response;
+  if (start.state !== 'started') return null;
+  try {
+    const res = await axios.post(`https://api.github.com/repos/${cfg.owner}/${cfg.repo}/issues`, { title: `Hermes task #${task.id}`, body: task.input_text }, { headers: { Authorization: `Bearer ${cfg.token}`, Accept: 'application/vnd.github+json' } });
+    await completeIdempotentAction(idemKey, res.data);
+    await updateSession(task.id, { issue_url: res.data.html_url });
+    return res.data;
+  } catch (e) { await failIdempotentAction(idemKey, e.message); throw e; }
+}
+
+async function commitChanges(task, session, summary, projectRoot) {
+  const msg = `hermes(task-${task.id}): ${String(summary || 'update').slice(0, 64)}`;
+  await execAsync('git add -A', { cwd: projectRoot, shell: '/bin/bash' });
+  await execAsync(`git commit -m ${JSON.stringify(msg)}`, { cwd: projectRoot, shell: '/bin/bash' });
+  return msg;
+}
+
+async function pushBranch(task, session, projectRoot) {
+  const branch = session.branch_name || createBranchName(task);
+  const idemKey = `push:${task.id}:${branch}`;
+  const start = await startIdempotentAction(idemKey, task.id, 'git_push', { branch });
+  if (start.state === 'completed') return start.existing.response;
+  if (start.state !== 'started') return { skipped: true, reason: start.state };
+  try {
+    const out = await execAsync(`git push -u origin ${branch}`, { cwd: projectRoot, shell: '/bin/bash' });
+    const response = { stdout: out.stdout || '', stderr: out.stderr || '', branch };
+    await completeIdempotentAction(idemKey, response);
+    return response;
+  } catch (e) { await failIdempotentAction(idemKey, e.message); throw e; }
+}
+
+async function createPullRequest(task, session, gateResult) {
+  const cfg = getGithubConfig();
+  if (!cfg.token || !cfg.owner || !cfg.repo) return null;
+  const branch = session.branch_name || createBranchName(task);
+  const idemKey = `pr:${task.id}:${branch}`;
+  const payload = { branch, gateResult };
+  const start = await startIdempotentAction(idemKey, task.id, 'create_pr', payload);
+  if (start.state === 'completed') return start.existing.response;
+  if (start.state !== 'started') return null;
+  const body = [
+    '## Hermes Task Summary', task.input_text || '-', '',
+    '## Files Changed', 'See commit diff in branch.', '',
+    '## Gate Result', gateResult || 'not_run', '',
+    '## Approval Status', 'Push approval required/executed by policy.', '',
+    '## Risks', 'Automated change. Validate before merge.', '',
+    '## Rollback Notes', `git revert or reset branch ${branch}.`
+  ].join('\n');
+  try {
+    const res = await axios.post(`https://api.github.com/repos/${cfg.owner}/${cfg.repo}/pulls`, { title: `Hermes task #${task.id}`, head: branch, base: cfg.base, body }, { headers: { Authorization: `Bearer ${cfg.token}`, Accept: 'application/vnd.github+json' } });
+    await completeIdempotentAction(idemKey, res.data);
+    await updateSession(task.id, { pr_url: res.data.html_url, branch_name: branch });
+    return res.data;
+  } catch (e) { await failIdempotentAction(idemKey, e.message); throw e; }
+}
+
+async function commentOnIssue(issueNumber, message) {
+  const cfg = getGithubConfig();
+  if (!cfg.token || !cfg.owner || !cfg.repo) return null;
+  return axios.post(`https://api.github.com/repos/${cfg.owner}/${cfg.repo}/issues/${issueNumber}/comments`, { body: message }, { headers: { Authorization: `Bearer ${cfg.token}`, Accept: 'application/vnd.github+json' } });
+}
+
+module.exports = { createIssueFromTask, createBranchName, commitChanges, pushBranch, createPullRequest, commentOnIssue };

--- a/dispatcher/goalRunner.js
+++ b/dispatcher/goalRunner.js
@@ -1,0 +1,67 @@
+const { query } = require('../db');
+const { executeAutomation, validateConfig } = require('./automation');
+const { startIdempotentAction, completeIdempotentAction, failIdempotentAction } = require('./idempotency');
+
+let lastSchedulerRunAt = 0;
+
+async function createGoalTask(goal, execution) {
+  const text = `[GOAL:${goal.id}] ${goal.name} - ${goal.config?.action || 'automation'}`;
+  const r = await query(
+    `insert into hermes_tasks (telegram_chat_id, telegram_user_id, input_text, status, intent, source, goal_id)
+     values ($1,$2,$3,'pending','automation',$4,$5) returning *`,
+    [Number(process.env.OWNER_CHAT_ID || 0), Number(process.env.OWNER_USER_ID || 0), text, 'goal', goal.id],
+  );
+  await query(`insert into hermes_task_events (task_id,event_type,message,payload) values ($1,'goal_task_created',$2,$3)`, [r.rows[0].id, 'Task created from goal execution', execution]);
+  return r.rows[0];
+}
+
+async function executeGoal(goal) {
+  const windowKey = `${goal.id}:${Math.floor(Date.now() / (5 * 60 * 1000))}`;
+  const idem = await startIdempotentAction(windowKey, null, 'goal_run', { goal_id: goal.id });
+  if (idem.state !== 'started') return { skipped: true, reason: idem.state };
+
+  try {
+    const cfg = goal.config || {};
+    validateConfig(cfg);
+    const result = await executeAutomation(cfg);
+    const task = await createGoalTask(goal, result);
+
+    await query(`update hermes_goals set last_run_at=now(), next_run_at=now() + make_interval(secs => schedule_interval_seconds), failure_count=0 where id=$1`, [goal.id]);
+    await completeIdempotentAction(windowKey, { goal_id: goal.id, task_id: task.id, result });
+    await query(`insert into hermes_memories (memory_key,memory_text,memory_type,importance,confidence,last_used_at) values ($1,$2,'business_rule',3,0.7,now())`, [`goal:${goal.id}:ok`, JSON.stringify({ goal_type: goal.type, action: cfg.action, success: true })]);
+    return { success: true, task_id: task.id, result };
+  } catch (e) {
+    await failIdempotentAction(windowKey, e.message);
+    const upd = await query(`update hermes_goals set failure_count=failure_count+1, next_run_at=now() + make_interval(secs => greatest(schedule_interval_seconds*2,30)) where id=$1 returning failure_count`, [goal.id]);
+    const failureCount = Number(upd.rows[0]?.failure_count || 0);
+    if (failureCount >= 3) await query(`update hermes_goals set status='failed' where id=$1`, [goal.id]);
+    await query(`insert into hermes_memories (memory_key,memory_text,memory_type,importance,confidence,last_used_at) values ($1,$2,'ops_sop',3,0.6,now())`, [`goal:${goal.id}:fail`, JSON.stringify({ pattern: 'goal failure', action: 'manual check required' })]);
+    return { success: false, error: e.message };
+  }
+}
+
+async function runDueGoals() {
+  try {
+    if (Date.now() - lastSchedulerRunAt < 30000) return { skipped: true, reason: 'interval_guard' };
+    lastSchedulerRunAt = Date.now();
+
+    const active = await query(`select * from hermes_goals where status='active' and next_run_at <= now() order by next_run_at asc limit 10`);
+    const results = [];
+    for (const goal of active.rows) {
+      const recent = await query(`select count(*)::int as c from hermes_idempotency_keys where action_type='goal_run' and created_at > now() - interval '1 hour' and response->>'goal_id' = $1`, [String(goal.id)]);
+      if (Number(recent.rows[0]?.c || 0) >= 3) continue;
+      results.push(await executeGoal(goal));
+    }
+    return { ran: results.length, results };
+  } catch (e) {
+    return { ran: 0, error: e.message };
+  }
+}
+
+async function runGoalNow(goalId) {
+  const g = await query(`select * from hermes_goals where id=$1`, [goalId]);
+  if (!g.rows[0]) throw new Error('goal_not_found');
+  return executeGoal(g.rows[0]);
+}
+
+module.exports = { runDueGoals, executeGoal, runGoalNow };

--- a/dispatcher/health.js
+++ b/dispatcher/health.js
@@ -1,0 +1,43 @@
+const { query } = require('../db');
+const envConfig = require('../config/env');
+
+async function getSystemHealth() {
+  let dbOk = true;
+  try { await query('select 1'); } catch { dbOk = false; }
+
+  const worker = await query(`select worker_id,last_heartbeat_at,status from hermes_worker_status order by last_heartbeat_at desc limit 1`);
+  const latestWorker = worker.rows[0] || null;
+
+  const q = await query(
+    `select
+      count(*) filter (where status='pending')::int as pending,
+      count(*) filter (where status='running')::int as running,
+      count(*) filter (where status='failed')::int as failed,
+      count(*) filter (where status='waiting_approval')::int as waiting_approval
+     from hermes_tasks`,
+  );
+
+  const m = await query(`select count(*)::int as total from hermes_memories`);
+
+  const running = q.rows[0]?.running || 0;
+  const status = !dbOk ? 'down' : running > 50 ? 'degraded' : 'ok';
+
+  return {
+    status,
+    env: envConfig.HERMES_ENV,
+    db: { ok: dbOk },
+    worker: {
+      alive: Boolean(latestWorker && latestWorker.last_heartbeat_at),
+      last_heartbeat_at: latestWorker?.last_heartbeat_at || null,
+    },
+    queue: {
+      pending: q.rows[0]?.pending || 0,
+      running: running,
+      failed: q.rows[0]?.failed || 0,
+      waiting_approval: q.rows[0]?.waiting_approval || 0,
+    },
+    memory: { total: m.rows[0]?.total || 0 },
+  };
+}
+
+module.exports = { getSystemHealth };

--- a/dispatcher/idempotency.js
+++ b/dispatcher/idempotency.js
@@ -1,0 +1,61 @@
+const crypto = require('crypto');
+const { query } = require('../db');
+
+function stableStringify(obj) {
+  if (obj === null || typeof obj !== 'object') return JSON.stringify(obj);
+  if (Array.isArray(obj)) return `[${obj.map(stableStringify).join(',')}]`;
+  return `{${Object.keys(obj).sort().map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
+}
+
+function hashPayload(payload) {
+  return crypto.createHash('sha256').update(stableStringify(payload || {})).digest('hex');
+}
+
+async function getExistingIdempotentAction(key) {
+  const res = await query('select * from hermes_idempotency_keys where key=$1', [key]);
+  return res.rows[0] || null;
+}
+
+async function startIdempotentAction(key, taskId, actionType, requestPayload = {}) {
+  const requestHash = hashPayload(requestPayload);
+  const existing = await getExistingIdempotentAction(key);
+  if (existing) {
+    if (existing.request_hash !== requestHash) return { state: 'conflict', existing };
+    if (existing.status === 'completed') return { state: 'completed', existing };
+    if (existing.status === 'started') return { state: 'already_running', existing };
+    return { state: 'failed', existing };
+  }
+
+  const inserted = await query(
+    `insert into hermes_idempotency_keys (key, task_id, action_type, status, request_hash)
+     values ($1,$2,$3,'started',$4) returning *`,
+    [key, taskId, actionType, requestHash],
+  );
+  return { state: 'started', record: inserted.rows[0] };
+}
+
+async function completeIdempotentAction(key, response = {}) {
+  await query(
+    `update hermes_idempotency_keys
+     set status='completed', response=$2, updated_at=now()
+     where key=$1`,
+    [key, response],
+  );
+}
+
+async function failIdempotentAction(key, error) {
+  await query(
+    `update hermes_idempotency_keys
+     set status='failed', error_text=$2, updated_at=now()
+     where key=$1`,
+    [key, String(error || '')],
+  );
+}
+
+module.exports = {
+  hashPayload,
+  getExistingIdempotentAction,
+  startIdempotentAction,
+  completeIdempotentAction,
+  failIdempotentAction,
+};

--- a/dispatcher/monitor.js
+++ b/dispatcher/monitor.js
@@ -1,0 +1,40 @@
+const { query } = require('../db');
+const { triggerAlert } = require('./alert');
+
+async function detectAndHandleStuckTasks() {
+  const stuck = await query(
+    `select id,retry_count,max_retries from hermes_tasks
+     where status='running' and heartbeat_at < now() - interval '10 minutes'`,
+  );
+
+  for (const t of stuck.rows) {
+    if (Number(t.retry_count) < Number(t.max_retries)) {
+      await query(`update hermes_tasks set status='pending', retry_count=retry_count+1, locked_by=null, locked_at=null, updated_at=now() where id=$1`, [t.id]);
+    } else {
+      await query(`update hermes_tasks set status='failed', locked_by=null, locked_at=null, updated_at=now(), error_text=coalesce(error_text,'stuck task exceeded retries') where id=$1`, [t.id]);
+    }
+    await triggerAlert('TASK_STUCK', { task_id: t.id, retry_count: t.retry_count, max_retries: t.max_retries });
+  }
+
+  return { stuck: stuck.rowCount || 0 };
+}
+
+async function checkHighFailureRate() {
+  const res = await query(
+    `select count(*)::int as c from hermes_tasks where status='failed' and updated_at > now() - interval '10 minutes'`,
+  );
+  const count = res.rows[0]?.c || 0;
+  if (count > 5) await triggerAlert('HIGH_FAILURE_RATE', { failed_last_10m: count });
+  return { failedLast10m: count };
+}
+
+async function checkStuckApprovals() {
+  const res = await query(
+    `select count(*)::int as c from hermes_approvals where status='pending' and created_at < now() - interval '15 minutes'`,
+  );
+  const count = res.rows[0]?.c || 0;
+  if (count > 0) await triggerAlert('APPROVAL_STUCK', { pending_approvals: count });
+  return { pendingApprovals: count };
+}
+
+module.exports = { detectAndHandleStuckTasks, checkHighFailureRate, checkStuckApprovals };

--- a/dispatcher/planExecutor.js
+++ b/dispatcher/planExecutor.js
@@ -1,0 +1,83 @@
+const { query } = require('../db');
+const { runGate } = require('./gate');
+const { handleTaskFailure } = require('./autodebug');
+const { commitChanges, createPullRequest } = require('./github');
+const { updateSession } = require('./session');
+
+async function markPlan(planId, status) {
+  await query(`update hermes_plans set status=$2 where id=$1`, [planId, status]);
+}
+
+async function runStep(planId, stepId, fn) {
+  const lock = await query(`update hermes_plan_steps set status='running', updated_at=now() where plan_id=$1 and step_id=$2 and status='pending' returning *`, [planId, stepId]);
+  if (!lock.rows[0]) return { skipped: true };
+  try {
+    const result = await Promise.race([fn(), new Promise((_, r) => setTimeout(() => r(new Error('step_timeout')), 120000))]);
+    await query(`update hermes_plan_steps set status='completed', result=$3, updated_at=now() where plan_id=$1 and step_id=$2`, [planId, stepId, result || {}]);
+    return { ok: true, result };
+  } catch (e) {
+    await query(`update hermes_plan_steps set status='failed', result=$3, updated_at=now() where plan_id=$1 and step_id=$2`, [planId, stepId, { error: e.message }]);
+    return { ok: false, error: e };
+  }
+}
+
+async function executePlan(plan, task, session, ctx) {
+  const start = Date.now();
+  await markPlan(plan.id, 'running');
+  await updateSession(task.id, { plan_id: plan.id });
+  let lastOutput = '';
+
+  const steps = await query(`select * from hermes_plan_steps where plan_id=$1 order by step_id asc`, [plan.id]);
+  for (const s of steps.rows) {
+    if (Date.now() - start > 10 * 60 * 1000) {
+      await markPlan(plan.id, 'failed');
+      throw new Error('plan_timeout');
+    }
+    if (s.status !== 'pending') continue;
+    await updateSession(task.id, { current_step_id: s.step_id });
+    if (ctx.onStep) await ctx.onStep(s.step_id, steps.rows.length);
+
+    let retries = 0;
+    while (retries <= 1) {
+      const outcome = await runStep(plan.id, s.step_id, async () => {
+        if (s.type === 'analyze') return { message: 'analyzed task/session', task_id: task.id };
+        if (s.type === 'locate') return { message: 'located likely files from task text' };
+        if (s.type === 'patch') return { output: await ctx.runAction(task) };
+        if (s.type === 'test') return await runGate(ctx.projectRoot);
+        if (s.type === 'commit') return { commit_message: await commitChanges(task, session, 'planned change', ctx.projectRoot) };
+        if (s.type === 'pr') return { pr: await createPullRequest(task, session, session.last_gate_status || 'PATCH DONE BUT GATE FAILED') };
+        return { skipped: true };
+      });
+
+      if (outcome.ok) {
+        lastOutput = JSON.stringify(outcome.result || {});
+        break;
+      }
+
+      if (s.type === 'patch') {
+        const debug = await handleTaskFailure(task, session, outcome.error.message, { projectRoot: ctx.projectRoot });
+        if (!debug.retryable) break;
+      }
+
+      retries += 1;
+      if (retries > 1) {
+        await markPlan(plan.id, 'failed');
+        throw outcome.error;
+      }
+      await query(`update hermes_plan_steps set status='pending' where plan_id=$1 and step_id=$2`, [plan.id, s.step_id]);
+    }
+  }
+
+  await markPlan(plan.id, 'completed');
+  await query(
+    `insert into hermes_memories (memory_key,memory_text,memory_type,importance,confidence,last_used_at)
+     values ($1,$2,'decision_log',3,0.7,now())`,
+    [
+      `decision:${task.id}`,
+      JSON.stringify({ task_type: (ctx.taskType || 'fix'), keywords: String(task.input_text || '').toLowerCase().split(/\W+/).slice(0, 5), steps: steps.rows.map((r) => r.type), success: true }),
+    ],
+  );
+  return { status: 'completed', output: lastOutput };
+}
+
+module.exports = { executePlan };

--- a/dispatcher/planner.js
+++ b/dispatcher/planner.js
@@ -1,0 +1,47 @@
+const { query } = require('../db');
+
+const KEYWORDS = ['fix', 'build', 'implement', 'refactor'];
+const DEFAULT_STEPS = ['analyze', 'locate', 'patch', 'test', 'pr'];
+
+function taskType(text = '') {
+  const t = text.toLowerCase();
+  return KEYWORDS.find((k) => t.includes(k)) || null;
+}
+
+async function findReusableSteps(task) {
+  const tType = taskType(task.input_text);
+  if (!tType) return null;
+  const words = String(task.input_text || '').toLowerCase().split(/\W+/).filter(Boolean).slice(0, 10);
+  const rows = await query(`select memory_text from hermes_memories where memory_type='decision_log' order by updated_at desc limit 20`);
+  for (const r of rows.rows) {
+    try {
+      const m = JSON.parse(r.memory_text);
+      if (m.task_type !== tType || !Array.isArray(m.keywords)) continue;
+      if (words.some((w) => m.keywords.includes(w)) && Array.isArray(m.steps) && m.steps.length) return m.steps.slice(0, 5);
+    } catch {}
+  }
+  return null;
+}
+
+async function createPlan(task) {
+  const tType = taskType(task.input_text);
+  if (!tType) return null;
+  const planKey = `${task.id}:plan`;
+  const existing = await query(`select * from hermes_plans where plan_key=$1 limit 1`, [planKey]);
+  if (existing.rows[0]) {
+    const steps = await query(`select step_id,type,status from hermes_plan_steps where plan_id=$1 order by step_id asc`, [existing.rows[0].id]);
+    return { ...existing.rows[0], plan_key: planKey, steps: steps.rows };
+  }
+
+  const reused = await findReusableSteps(task);
+  const stepTypes = (reused || DEFAULT_STEPS).slice(0, 5);
+  const planRes = await query(`insert into hermes_plans (task_id,plan_key,status) values ($1,$2,'pending') returning *`, [task.id, planKey]);
+  const plan = planRes.rows[0];
+  for (let i = 0; i < stepTypes.length; i++) {
+    await query(`insert into hermes_plan_steps (plan_id,step_id,type,status,result,updated_at) values ($1,$2,$3,'pending','{}',now())`, [plan.id, i + 1, stepTypes[i]]);
+  }
+  const steps = await query(`select step_id,type,status from hermes_plan_steps where plan_id=$1 order by step_id asc`, [plan.id]);
+  return { ...plan, plan_key: planKey, steps: steps.rows };
+}
+
+module.exports = { createPlan, taskType };

--- a/dispatcher/queue.js
+++ b/dispatcher/queue.js
@@ -1,0 +1,108 @@
+const { query } = require('../db');
+
+async function logEvent(taskId, eventType, message, payload = {}) {
+  await query(
+    `insert into hermes_task_events (task_id, event_type, message, payload) values ($1,$2,$3,$4)`,
+    [taskId, eventType, message, payload],
+  );
+}
+
+async function claimNextTask(workerId) {
+  const res = await query(
+    `with next_task as (
+      select id from hermes_tasks
+      where status='pending'
+      order by id asc
+      limit 1
+      for update skip locked
+    )
+    update hermes_tasks t
+    set status='running', locked_by=$1, locked_at=now(), heartbeat_at=now(), timeout_at=now()+interval '10 minutes', updated_at=now()
+    from next_task
+    where t.id = next_task.id
+    returning t.*`,
+    [workerId],
+  );
+  const task = res.rows[0] || null;
+  if (task) await logEvent(task.id, 'claimed', 'Task claimed by worker', { workerId });
+  return task;
+}
+
+async function heartbeatTask(taskId, workerId) {
+  const res = await query(
+    `update hermes_tasks set heartbeat_at=now(), timeout_at=now()+interval '10 minutes', updated_at=now()
+     where id=$1 and locked_by=$2 and status='running' returning id`,
+    [taskId, workerId],
+  );
+  return (res.rowCount || 0) === 1;
+}
+
+async function releaseTask(taskId, workerId, status = 'completed', result = null) {
+  await query(
+    `update hermes_tasks
+     set status=$3, result_text=coalesce($4, result_text), locked_by=null, locked_at=null, timeout_at=null, heartbeat_at=now(), updated_at=now()
+     where id=$1 and locked_by=$2`,
+    [taskId, workerId, status, result],
+  );
+  await logEvent(taskId, status, `Task moved to ${status}`, { workerId });
+}
+
+async function failTask(taskId, workerId, errorText, retryable = true) {
+  const taskRes = await query('select retry_count,max_retries from hermes_tasks where id=$1', [taskId]);
+  const task = taskRes.rows[0];
+  if (!task) return;
+  const canRetry = retryable && Number(task.retry_count) < Number(task.max_retries);
+  if (canRetry) {
+    await query(
+      `update hermes_tasks
+       set status='pending', retry_count=retry_count+1, error_text=$3, locked_by=null, locked_at=null, timeout_at=null, updated_at=now()
+       where id=$1 and locked_by=$2`,
+      [taskId, workerId, String(errorText || '')],
+    );
+    await logEvent(taskId, 'retry_scheduled', 'Task scheduled for retry', { workerId });
+    return;
+  }
+  await query(
+    `update hermes_tasks
+     set status='failed', error_text=$3, locked_by=null, locked_at=null, timeout_at=null, updated_at=now()
+     where id=$1 and locked_by=$2`,
+    [taskId, workerId, String(errorText || '')],
+  );
+  await logEvent(taskId, 'failed', 'Task failed permanently', { workerId });
+}
+
+async function markWaitingApproval(taskId, workerId, approvalId) {
+  await query(
+    `update hermes_tasks
+     set status='waiting_approval', locked_by=null, locked_at=null, timeout_at=null, updated_at=now()
+     where id=$1 and locked_by=$2`,
+    [taskId, workerId],
+  );
+  await logEvent(taskId, 'waiting_approval', 'Task waiting approval', { workerId, approvalId });
+}
+
+async function recoverStaleTasks() {
+  const recovered = await query(
+    `update hermes_tasks
+     set status='pending', retry_count=retry_count+1, locked_by=null, locked_at=null, updated_at=now()
+     where status='running'
+       and heartbeat_at < now() - interval '10 minutes'
+       and retry_count < max_retries
+     returning id`,
+  );
+  for (const row of recovered.rows) await logEvent(row.id, 'stale_recovered', 'Recovered stale running task', {});
+
+  const failed = await query(
+    `update hermes_tasks
+     set status='failed', locked_by=null, locked_at=null, updated_at=now(), error_text=coalesce(error_text,'stale timeout exceeded')
+     where status='running'
+       and heartbeat_at < now() - interval '10 minutes'
+       and retry_count >= max_retries
+     returning id`,
+  );
+  for (const row of failed.rows) await logEvent(row.id, 'stale_failed', 'Stale task failed after retries', {});
+
+  return { recovered: recovered.rowCount || 0, failed: failed.rowCount || 0 };
+}
+
+module.exports = { claimNextTask, heartbeatTask, releaseTask, failTask, markWaitingApproval, recoverStaleTasks };

--- a/dispatcher/reviewer.js
+++ b/dispatcher/reviewer.js
@@ -1,0 +1,28 @@
+const { query } = require('../db');
+
+async function reviewTask(task, session, result) {
+  const issues = [];
+
+  if ((session.last_gate_status || '').toLowerCase() !== 'patch done and gate passed' && (session.last_gate_status || '').toLowerCase() !== 'passed') {
+    issues.push('Gate status is not passed');
+  }
+
+  if (session.plan_id) {
+    const steps = await query(`select status from hermes_plan_steps where plan_id=$1`, [session.plan_id]);
+    if (steps.rows.some((s) => s.status !== 'completed')) issues.push('Plan has incomplete/failed steps');
+  }
+
+  if (result && result.error) issues.push('Execution returned error');
+
+  const pendingApprovals = await query(`select count(*)::int as c from hermes_approvals where task_id=$1 and status in ('pending','approved')`, [task.id]);
+  if ((pendingApprovals.rows[0]?.c || 0) > 0) issues.push('Approval required but not executed');
+
+  const codeTask = /(fix|build|implement|refactor)/i.test(task.input_text || '');
+  if (codeTask && result?.patch_applied && !session.pr_url && !result?.pr_skipped_reason) issues.push('PR missing without skip reason');
+
+  const approved = issues.length === 0;
+  const confidence = approved ? 0.85 : 0.6;
+  return { approved, issues, confidence };
+}
+
+module.exports = { reviewTask };

--- a/dispatcher/roleController.js
+++ b/dispatcher/roleController.js
@@ -1,0 +1,51 @@
+const { createPlan, taskType } = require('./planner');
+const { executePlan } = require('./planExecutor');
+const { reviewTask } = require('./reviewer');
+const { query } = require('../db');
+const { startIdempotentAction, completeIdempotentAction } = require('./idempotency');
+const { updateSession } = require('./session');
+
+function short(text) { return String(text || '').slice(0, 120); }
+
+async function storeReviewMemory(task, review) {
+  if (review.approved) {
+    await query(`insert into hermes_memories (memory_key,memory_text,memory_type,importance,confidence,last_used_at)
+      values ($1,$2,'decision_log',3,0.8,now())`, [`review:${task.id}`, JSON.stringify({ pattern: 'successful flow', success: true })]);
+  } else if (review.issues.length) {
+    await query(`insert into hermes_memories (memory_key,memory_text,memory_type,importance,confidence,last_used_at)
+      values ($1,$2,'coding_rule',3,0.6,now())`, [`review:${task.id}`, JSON.stringify({ issue_pattern: short(review.issues[0]), suggestion: 'Fix gate/plan/approval before complete' })]);
+  }
+}
+
+async function runWithRoles(task, session, ctx) {
+  const plan = createPlan(task);
+  const resolvedPlan = await plan;
+  let execResult;
+  if (resolvedPlan) {
+    execResult = await executePlan(resolvedPlan, task, session, ctx);
+  } else {
+    const output = await ctx.runAction(task);
+    execResult = { status: 'completed', output, patch_applied: /patch/i.test(output || '') };
+  }
+
+  const reviewKey = `${task.id}:review`;
+  const start = await startIdempotentAction(reviewKey, task.id, 'review', { status: execResult.status });
+  if (start.state === 'completed') return start.existing.response;
+
+  const refreshed = (await query(`select * from hermes_sessions where task_id=$1`, [task.id])).rows[0] || session;
+  const review = await reviewTask(task, refreshed, execResult);
+  await updateSession(task.id, { review_status: review.approved ? 'approved' : 'rejected', review_confidence: review.confidence, last_error: review.approved ? null : short(review.issues.join('; ')) });
+  await storeReviewMemory(task, review);
+
+  const final = {
+    status: review.approved ? 'completed' : 'failed',
+    review_status: review.approved ? 'approved' : 'rejected',
+    review_confidence: review.confidence,
+    issues: review.issues,
+    output: execResult.output || null,
+  };
+  await completeIdempotentAction(reviewKey, final);
+  return final;
+}
+
+module.exports = { runWithRoles };

--- a/dispatcher/safety.js
+++ b/dispatcher/safety.js
@@ -1,0 +1,42 @@
+const SAFE_PATTERNS = [
+  /^ls(\s|$)/,
+  /^cat(\s|$)/,
+  /^grep(\s|$)/,
+  /^git status(\s|$)/,
+  /^git diff(\s|$)/,
+  /^npm (test|run test|run build|build)(\s|$)/,
+];
+
+const RISKY_PATTERNS = [
+  /^git commit(\s|$)/,
+  /^npm install(\s|$)/,
+  /^docker restart(\s|$)/,
+];
+
+const DANGEROUS_PATTERNS = [
+  /^rm(\s|$)/,
+  /^git reset --hard(\s|$)/,
+  /^docker down(\s|$)/,
+  /\bmigration\b/,
+  /^git push(\s|$)/,
+];
+
+function classifyCommand(command) {
+  const cmd = String(command || '').trim().toLowerCase();
+  if (!cmd) return { allowed: false, riskLevel: 'unknown', reason: 'empty command' };
+  if (DANGEROUS_PATTERNS.some((p) => p.test(cmd))) return { allowed: true, riskLevel: 'dangerous' };
+  if (RISKY_PATTERNS.some((p) => p.test(cmd))) return { allowed: true, riskLevel: 'risky' };
+  if (SAFE_PATTERNS.some((p) => p.test(cmd))) return { allowed: true, riskLevel: 'safe' };
+  return { allowed: false, riskLevel: 'unknown', reason: 'unknown command' };
+}
+
+function shouldRequireApproval(command, envName) {
+  const c = classifyCommand(command);
+  if (!c.allowed) return { ...c, requiresApproval: false };
+  const isProd = envName === 'prod';
+  if (c.riskLevel === 'dangerous') return { ...c, requiresApproval: true };
+  if (c.riskLevel === 'risky' && isProd) return { ...c, requiresApproval: true };
+  return { ...c, requiresApproval: false };
+}
+
+module.exports = { classifyCommand, shouldRequireApproval };

--- a/dispatcher/session.js
+++ b/dispatcher/session.js
@@ -1,0 +1,28 @@
+const { query } = require('../db');
+
+async function getOrCreateSession(taskId) {
+  const existing = await query('select * from hermes_sessions where task_id=$1', [taskId]);
+  if (existing.rows[0]) return existing.rows[0];
+  const created = await query(
+    `insert into hermes_sessions (task_id, status) values ($1, 'running') returning *`,
+    [taskId],
+  );
+  return created.rows[0];
+}
+
+async function updateSession(taskId, patch = {}) {
+  const keys = Object.keys(patch);
+  if (!keys.length) return;
+  const sets = keys.map((k, i) => `${k}=$${i + 2}`);
+  const values = keys.map((k) => patch[k]);
+  await query(`update hermes_sessions set ${sets.join(', ')} where task_id=$1`, [taskId, ...values]);
+}
+
+async function logSessionAction(sessionId, actionType, status, payload = {}) {
+  await query(
+    `insert into hermes_session_actions (session_id, action_type, status, payload) values ($1,$2,$3,$4)`,
+    [sessionId, actionType, status, payload],
+  );
+}
+
+module.exports = { getOrCreateSession, updateSession, logSessionAction };

--- a/gbrain.js
+++ b/gbrain.js
@@ -53,6 +53,15 @@ async function ensureGBrainSchema() {
 
     alter table hermes_approvals
       add column if not exists executed_at timestamptz;
+
+    alter table hermes_memories
+      add column if not exists memory_type text default 'project_context';
+    alter table hermes_memories
+      add column if not exists importance int default 3;
+    alter table hermes_memories
+      add column if not exists confidence numeric default 0.7;
+    alter table hermes_memories
+      add column if not exists last_used_at timestamptz;
   `);
 
 }
@@ -147,7 +156,7 @@ async function learnFromText(input, source = "telegram") {
   };
 }
 
-async function recallMemories(searchText) {
+async function recallMemories(searchText, memoryType = null) {
   const q = `%${searchText}%`;
 
   const result = await query(
@@ -165,6 +174,17 @@ async function recallMemories(searchText) {
   return result.rows;
 }
 
+
+async function recallStructuredMemories(memoryType) {
+  const result = await query(
+    `select * from hermes_memories where memory_type=$1 order by coalesce(last_used_at, updated_at, created_at) desc limit 10`,
+    [memoryType],
+  );
+  if (result.rows.length) {
+    await query(`update hermes_memories set last_used_at=now() where id = any($1::bigint[])`, [result.rows.map((r) => r.id)]);
+  }
+  return result.rows;
+}
 async function runHermesDispatcher(input) {
 
   const lowerInput = String(input || "").toLowerCase();
@@ -849,6 +869,7 @@ NEXT ACTION:
 
 
 module.exports = {
+  recallStructuredMemories,
   ensureGBrainSchema,
   learnFromText,
   recallMemories,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const axios = require("axios");
 const { query } = require("./db");
+const { getSystemHealth } = require("./dispatcher/health");
 const {
   ensureGBrainSchema,
   learnFromText,
@@ -13,6 +14,17 @@ const {
 } = require("./gbrain");
 const app = express();
 app.use(express.json());
+
+app.get('/health', async (_req, res) => {
+  try {
+    const health = await getSystemHealth();
+    const code = health.status === 'down' ? 503 : 200;
+    return res.status(code).json(health);
+  } catch (_e) {
+    return res.status(503).json({ status: 'down', env: process.env.HERMES_ENV || 'dev', db: { ok: false } });
+  }
+});
+
 
 const OWNER_CHAT_ID = process.env.OWNER_CHAT_ID;
 const AUTO_DAILY_ENABLED = process.env.AUTO_DAILY_ENABLED === "true";

--- a/patch_schema.sql
+++ b/patch_schema.sql
@@ -8,3 +8,119 @@ create table if not exists hermes_patches (
   approved_at timestamptz,
   applied_at timestamptz
 );
+
+create table if not exists hermes_approvals (
+  id bigserial primary key,
+  task_id bigint references hermes_tasks(id) on delete cascade,
+  status text not null default 'pending',
+  action_type text not null,
+  risk_level text not null,
+  approval_token text unique not null,
+  expires_at timestamptz not null,
+  created_at timestamptz default now(),
+  executed_at timestamptz
+);
+
+create table if not exists hermes_sessions (
+  id bigserial primary key,
+  task_id bigint unique references hermes_tasks(id) on delete cascade,
+  status text,
+  branch_name text,
+  patch_id bigint,
+  pr_url text,
+  last_error text,
+  last_gate_status text
+);
+
+create table if not exists hermes_session_actions (
+  id bigserial primary key,
+  session_id bigint references hermes_sessions(id) on delete cascade,
+  action_type text not null,
+  status text not null,
+  payload jsonb default '{}'::jsonb,
+  created_at timestamptz default now()
+);
+
+alter table hermes_memories add column if not exists memory_type text default 'project_context';
+alter table hermes_memories add column if not exists importance int default 3;
+alter table hermes_memories add column if not exists confidence numeric default 0.7;
+alter table hermes_memories add column if not exists last_used_at timestamptz;
+
+alter table hermes_tasks add column if not exists retry_count integer default 0;
+alter table hermes_tasks add column if not exists max_retries integer default 3;
+alter table hermes_tasks add column if not exists locked_by text;
+alter table hermes_tasks add column if not exists locked_at timestamptz;
+alter table hermes_tasks add column if not exists heartbeat_at timestamptz;
+alter table hermes_tasks add column if not exists idempotency_key text;
+alter table hermes_tasks add column if not exists timeout_at timestamptz;
+
+alter table hermes_approvals add column if not exists payload_hash text;
+alter table hermes_approvals add column if not exists executed_by text;
+alter table hermes_approvals add column if not exists idempotency_key text;
+
+create table if not exists hermes_idempotency_keys (
+  id bigserial primary key,
+  key text unique not null,
+  task_id bigint references hermes_tasks(id) on delete set null,
+  action_type text not null,
+  status text not null default 'started',
+  request_hash text,
+  response jsonb default '{}'::jsonb,
+  error_text text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create index if not exists hermes_tasks_status_idx on hermes_tasks(status);
+create index if not exists hermes_tasks_heartbeat_idx on hermes_tasks(heartbeat_at);
+create index if not exists hermes_idempotency_task_idx on hermes_idempotency_keys(task_id);
+
+create table if not exists hermes_worker_status (
+  worker_id text primary key,
+  last_heartbeat_at timestamptz,
+  status text
+);
+create index if not exists hermes_worker_status_heartbeat_idx on hermes_worker_status(last_heartbeat_at);
+
+alter table hermes_sessions add column if not exists debug_attempts integer default 0;
+alter table hermes_sessions add column if not exists last_error_type text;
+
+create table if not exists hermes_plans (
+  id bigserial primary key,
+  task_id bigint references hermes_tasks(id) on delete cascade,
+  plan_key text unique,
+  status text not null default 'pending',
+  created_at timestamptz default now()
+);
+
+create table if not exists hermes_plan_steps (
+  id bigserial primary key,
+  plan_id bigint references hermes_plans(id) on delete cascade,
+  step_id integer not null,
+  type text not null,
+  status text not null default 'pending',
+  result jsonb default '{}'::jsonb,
+  updated_at timestamptz default now(),
+  unique(plan_id, step_id)
+);
+
+alter table hermes_sessions add column if not exists plan_id bigint;
+alter table hermes_sessions add column if not exists current_step_id integer;
+alter table hermes_sessions add column if not exists review_status text;
+alter table hermes_sessions add column if not exists review_confidence numeric;
+
+create table if not exists hermes_goals (
+  id bigserial primary key,
+  name text not null,
+  type text not null,
+  status text not null default 'active',
+  schedule_interval_seconds integer not null,
+  last_run_at timestamptz,
+  next_run_at timestamptz not null default now(),
+  failure_count integer not null default 0,
+  config jsonb not null default '{}'::jsonb,
+  created_at timestamptz default now()
+);
+alter table hermes_tasks add column if not exists source text;
+alter table hermes_tasks add column if not exists goal_id bigint references hermes_goals(id) on delete set null;
+create index if not exists hermes_goals_status_next_run_idx on hermes_goals(status,next_run_at);

--- a/schema.sql
+++ b/schema.sql
@@ -54,3 +54,114 @@ create table if not exists hermes_action_logs (
   status text not null,
   created_at timestamptz default now()
 );
+
+create table if not exists hermes_approvals (
+  id bigserial primary key,
+  task_id bigint references hermes_tasks(id) on delete cascade,
+  status text not null default 'pending',
+  action_type text not null,
+  risk_level text not null,
+  approval_token text unique not null,
+  expires_at timestamptz not null,
+  created_at timestamptz default now(),
+  executed_at timestamptz
+);
+
+create table if not exists hermes_sessions (
+  id bigserial primary key,
+  task_id bigint unique references hermes_tasks(id) on delete cascade,
+  status text,
+  branch_name text,
+  patch_id bigint,
+  pr_url text,
+  last_error text,
+  last_gate_status text
+);
+
+create table if not exists hermes_session_actions (
+  id bigserial primary key,
+  session_id bigint references hermes_sessions(id) on delete cascade,
+  action_type text not null,
+  status text not null,
+  payload jsonb default '{}'::jsonb,
+  created_at timestamptz default now()
+);
+
+alter table hermes_tasks add column if not exists retry_count integer default 0;
+alter table hermes_tasks add column if not exists max_retries integer default 3;
+alter table hermes_tasks add column if not exists locked_by text;
+alter table hermes_tasks add column if not exists locked_at timestamptz;
+alter table hermes_tasks add column if not exists heartbeat_at timestamptz;
+alter table hermes_tasks add column if not exists idempotency_key text;
+alter table hermes_tasks add column if not exists timeout_at timestamptz;
+
+alter table hermes_approvals add column if not exists payload_hash text;
+alter table hermes_approvals add column if not exists executed_by text;
+alter table hermes_approvals add column if not exists idempotency_key text;
+
+create table if not exists hermes_idempotency_keys (
+  id bigserial primary key,
+  key text unique not null,
+  task_id bigint references hermes_tasks(id) on delete set null,
+  action_type text not null,
+  status text not null default 'started',
+  request_hash text,
+  response jsonb default '{}'::jsonb,
+  error_text text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create index if not exists hermes_tasks_status_idx on hermes_tasks(status);
+create index if not exists hermes_tasks_heartbeat_idx on hermes_tasks(heartbeat_at);
+create index if not exists hermes_idempotency_task_idx on hermes_idempotency_keys(task_id);
+
+create table if not exists hermes_worker_status (
+  worker_id text primary key,
+  last_heartbeat_at timestamptz,
+  status text
+);
+create index if not exists hermes_worker_status_heartbeat_idx on hermes_worker_status(last_heartbeat_at);
+
+alter table hermes_sessions add column if not exists debug_attempts integer default 0;
+alter table hermes_sessions add column if not exists last_error_type text;
+
+create table if not exists hermes_plans (
+  id bigserial primary key,
+  task_id bigint references hermes_tasks(id) on delete cascade,
+  plan_key text unique,
+  status text not null default 'pending',
+  created_at timestamptz default now()
+);
+
+create table if not exists hermes_plan_steps (
+  id bigserial primary key,
+  plan_id bigint references hermes_plans(id) on delete cascade,
+  step_id integer not null,
+  type text not null,
+  status text not null default 'pending',
+  result jsonb default '{}'::jsonb,
+  updated_at timestamptz default now(),
+  unique(plan_id, step_id)
+);
+
+alter table hermes_sessions add column if not exists plan_id bigint;
+alter table hermes_sessions add column if not exists current_step_id integer;
+alter table hermes_sessions add column if not exists review_status text;
+alter table hermes_sessions add column if not exists review_confidence numeric;
+
+create table if not exists hermes_goals (
+  id bigserial primary key,
+  name text not null,
+  type text not null,
+  status text not null default 'active',
+  schedule_interval_seconds integer not null,
+  last_run_at timestamptz,
+  next_run_at timestamptz not null default now(),
+  failure_count integer not null default 0,
+  config jsonb not null default '{}'::jsonb,
+  created_at timestamptz default now()
+);
+alter table hermes_tasks add column if not exists source text;
+alter table hermes_tasks add column if not exists goal_id bigint references hermes_goals(id) on delete set null;
+create index if not exists hermes_goals_status_next_run_idx on hermes_goals(status,next_run_at);

--- a/worker.js
+++ b/worker.js
@@ -6,26 +6,28 @@ const fs = require("fs");
 const path = require("path");
 const { query } = require("./db");
 const envConfig = require("./config/env");
-const { checkCommand } = require("./config/commandGuard");
+const { shouldRequireApproval } = require('./dispatcher/safety');
+const { getOrCreateSession, updateSession, logSessionAction } = require('./dispatcher/session');
+const { runGate } = require('./dispatcher/gate');
+const { claimNextTask, heartbeatTask, releaseTask, failTask, recoverStaleTasks } = require('./dispatcher/queue');
 const { validateReplyTarget } = require("./config/dbGuard");
+const { detectAndHandleStuckTasks, checkHighFailureRate, checkStuckApprovals } = require('./dispatcher/monitor');
+const { handleTaskFailure } = require('./dispatcher/autodebug');
+const { createPlan, taskType } = require('./dispatcher/planner');
+const { executePlan } = require('./dispatcher/planExecutor');
+const { runWithRoles } = require('./dispatcher/roleController');
+const { runDueGoals } = require('./dispatcher/goalRunner');
 
 const rawExecAsync = promisify(exec);
 
 async function execAsync(command, options = {}) {
-  const decision = checkCommand(command, envConfig.APP_ENV);
-
-  if (!decision.allowed) {
-    throw new Error(`[command] blocked reason=${decision.reason}`);
-  }
-
-  if (decision.requiresApproval) {
-    throw new Error(`[command] blocked reason=${decision.reason} requiresApproval=true`);
-  }
-
+  const decision = shouldRequireApproval(command, envConfig.HERMES_ENV);
+  if (!decision.allowed) throw new Error(`[command] blocked reason=${decision.reason}`);
+  if (decision.requiresApproval) throw new Error(`[command] blocked reason=approval_required risk=${decision.riskLevel}`);
   return rawExecAsync(command, options);
 }
 
-const TELEGRAM_TOKEN = process.env.TELEGRAM_TOKEN;
+const TELEGRAM_TOKEN = envConfig.TELEGRAM_TOKEN || process.env.TELEGRAM_TOKEN;
 const TELEGRAM_API = `https://api.telegram.org/bot${TELEGRAM_TOKEN}`;
 
 const PROJECT_ROOT = envConfig.projectRoot;
@@ -1072,47 +1074,83 @@ ${memoryContext}
   return response.choices?.[0]?.message?.content || "Hermes chưa tạo được câu trả lời.";
 }
 
-async function processOneTask() {
-  const result = await query(
-    `select * from hermes_tasks where status='pending' order by id asc limit 1`
-  );
+const WORKER_ID = process.env.HERMES_WORKER_ID || `worker-${process.pid}`;
 
-  const task = result.rows[0];
+async function upsertWorkerHeartbeat(status = 'alive') {
+  await query(`insert into hermes_worker_status (worker_id, last_heartbeat_at, status) values ($1, now(), $2)\n    on conflict (worker_id) do update set last_heartbeat_at=excluded.last_heartbeat_at, status=excluded.status`, [WORKER_ID, status]);
+}
+
+
+async function processOneTask() {
+  const task = await claimNextTask(WORKER_ID);
   if (!task) return;
 
   try {
-    await query(`update hermes_tasks set status='running', updated_at=now() where id=$1`, [task.id]);
+    await upsertWorkerHeartbeat('alive');
+    await heartbeatTask(task.id, WORKER_ID);
+    const heartbeatTimer = setInterval(() => { heartbeatTask(task.id, WORKER_ID).catch(() => {}); upsertWorkerHeartbeat('alive').catch(() => {}); }, 12000);
+    const session = await getOrCreateSession(task.id);
     await event(task.id, "started", "Worker started task");
 
-    const output = await runAction(task);
+    const finalResult = await runWithRoles(task, session, {
+      runAction,
+      projectRoot: PROJECT_ROOT,
+      taskType: taskType(task.input_text || ''),
+    });
+    await sendTelegramMessage(task.telegram_chat_id, `Task executed, under review`, null, task.telegram_user_id);
 
-    await query(
-      `update hermes_tasks set status='completed', result_text=$1, updated_at=now() where id=$2`,
-      [output, task.id]
-    );
+    await updateSession(task.id, { status: finalResult.status, last_gate_status: finalResult.review_status === 'approved' ? 'passed' : 'failed' });
+    await logSessionAction(session.id, 'review', finalResult.review_status, finalResult);
+
+    if (finalResult.review_status === 'approved') {
+      await releaseTask(task.id, WORKER_ID, 'completed', JSON.stringify(finalResult));
+      await sendTelegramMessage(task.telegram_chat_id, `Task approved`, null, task.telegram_user_id);
+    } else {
+      await failTask(task.id, WORKER_ID, (finalResult.issues || []).join('; '), false);
+      await sendTelegramMessage(task.telegram_chat_id, `Task rejected: ${(finalResult.issues || ['unknown']).join('; ')}`, null, task.telegram_user_id);
+    }
 
     await event(task.id, "completed", "Task completed");
-    await sendTelegramMessage(task.telegram_chat_id, `Task #${task.id} hoàn tất:
-
-${output}`, null, task.telegram_user_id);
+    clearInterval(heartbeatTimer);
+    await sendTelegramMessage(task.telegram_chat_id, `Task #${task.id} hoàn tất`, null, task.telegram_user_id);
 
   } catch (err) {
+    try { clearInterval(heartbeatTimer); } catch (_) {}
     const errorText = err.response?.data ? JSON.stringify(err.response.data) : err.message;
+    const session = await getOrCreateSession(task.id);
+    const debug = await handleTaskFailure(task, session, errorText, {
+      projectRoot: PROJECT_ROOT,
+      onFirstDebugAttempt: async (msg) => sendTelegramMessage(task.telegram_chat_id, msg, null, task.telegram_user_id),
+    });
 
-    await query(
-      `update hermes_tasks set status='failed', error_text=$1, updated_at=now() where id=$2`,
-      [errorText, task.id]
-    );
+    const enriched = {
+      status: 'failed',
+      error_type: debug.error_type || 'UNKNOWN',
+      debug_attempts: debug.debug_attempts || session.debug_attempts || 0,
+      auto_fix: Boolean(debug.auto_fix),
+      final_state: debug.auto_fix ? 'recovered' : 'failed',
+    };
 
-    await event(task.id, "failed", errorText);
-    await sendTelegramMessage(task.telegram_chat_id, `Task #${task.id} bị lỗi:
-${errorText}`, null, task.telegram_user_id);
+    await updateSession(task.id, { status: 'failed', last_error: errorText });
+
+    await failTask(task.id, WORKER_ID, errorText, Boolean(debug.retryable));
+
+    await event(task.id, "failed", errorText, enriched);
+    await sendTelegramMessage(task.telegram_chat_id, `Plan failed at step ${session.current_step_id || '-'}`, null, task.telegram_user_id).catch(()=>{});
+    await sendTelegramMessage(task.telegram_chat_id, `Task #${task.id} result:
+${JSON.stringify(enriched)}`, null, task.telegram_user_id);
 
   }
 }
 
 async function loop() {
   try {
+    await upsertWorkerHeartbeat('alive');
+    await recoverStaleTasks();
+    await detectAndHandleStuckTasks().catch(() => {});
+    await checkStuckApprovals().catch(() => {});
+    await checkHighFailureRate().catch(() => {});
+    await runDueGoals().catch(() => {});
     await processOneTask();
   } catch (err) {
     console.error("Worker loop error:", err.message);


### PR DESCRIPTION
### Motivation
- Introduce robust dispatcher primitives to support safe automated code changes, retries, approvals, and idempotent actions. 
- Add operational observability and worker coordination (health, heartbeats, stuck-detection) to reduce duplicate work and recover stale tasks. 
- Provide safe command classification and approval flow to prevent dangerous operations in production. 
- Integrate GitHub automation and planning/role-based execution to generate branches/PRs and structured plans for code-change tasks.

### Description
- Added many new dispatcher modules: `queue`, `idempotency`, `monitor`, `alert`, `autodebug`, `automation`, `errorClassifier`, `gate`, `github`, `goalRunner`, `planExecutor`, `planner`, `reviewer`, `roleController`, `safety`, and `session` to handle task lifecycle, retries, scheduling, automated debugging, planning and review. 
- Implemented approvals and payload hashing in `dispatcher/approval.ts` to support token creation and single-use, payload-validated consumption with idempotency key support. 
- Reworked environment config in `config/env.js` to use `HERMES_ENV` (dev|prod), separate project roots for dev/prod, safer telegram token resolution and additional exported config values. 
- Updated worker and index wiring: worker now claims tasks via `queue`, maintains heartbeats in `hermes_worker_status`, runs plan/role flows, invokes autodebug on failures, and integrates monitors and goal runner; `index.js` exposes a `/health` endpoint using new health checks. 
- Added idempotency storage and helpers (`hermes_idempotency_keys`) and many schema migrations in `schema.sql` and `patch_schema.sql` to add approvals, sessions, plans, plan steps, goals, worker status, task retry/lock fields, indices, and other required columns. 
- Introduced lightweight safety checks/classification for commands and automation tasks, plus alerting via Telegram and action logs. 
- Added `MANUAL_TEST_NOTES.md` expansion documenting queue/approval/idempotency/PR-agent scenarios and other manual test cases.

### Testing
- Applied schema changes via the included SQL migrations and validated new columns/tables exist (smoke migration run succeeded). 
- Performed basic smoke-starts of the HTTP server and worker to verify `/health` responds and worker can heartbeat and claim tasks (smoke runs succeeded). 
- Ran project lint and existing automated test suite (`npm run lint` and `npm test`) against the changes locally and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3377425888333902f3775ba2d3ef1)