### PR TITLE
Fix Telegram /start, /help, /health early routing in polling handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -818,6 +818,37 @@ if (callback) {
       const normalized = text.toLowerCase();
       console.log("INCOMING:", { userId, text });
 
+      await query(
+        `insert into telegram_users (telegram_user_id, is_allowed)
+         values ($1, $2)
+         on conflict (telegram_user_id)
+         do update set last_seen_at = now()`,
+        [userId, isAllowed(userId)]
+      );
+
+      if (!isAllowed(userId)) {
+        await sendTelegramMessage(chatId, "Bạn không có quyền sử dụng Hermes.");
+        continue;
+      }
+
+      if (normalized === "/start") {
+        await sendTelegramMessage(chatId, "👋 Hermes đã sẵn sàng.\n\nGõ /help để xem lệnh.");
+        console.log("COMMAND_HANDLED /start", { userId, chatId });
+        continue;
+      }
+
+      if (normalized === "/help") {
+        await sendTelegramMessage(chatId, "Gõ /commands để xem toàn bộ lệnh Hermes.");
+        console.log("COMMAND_HANDLED /help", { userId, chatId });
+        continue;
+      }
+
+      if (normalized === "/health") {
+        await sendTelegramMessage(chatId, "Hermes app online ✅\nWorker sẽ xử lý task trong nền.");
+        console.log("COMMAND_HANDLED /health", { userId, chatId });
+        continue;
+      }
+
       if (text === "/commands") {
   await sendTelegramMessage(chatId, `📚 Hermes Commands
 
@@ -1007,26 +1038,8 @@ if (session.rows[0]?.state === "awaiting_codex") {
   continue;
 }
 
-      await query(
-        `insert into telegram_users (telegram_user_id, is_allowed)
-         values ($1, $2)
-         on conflict (telegram_user_id)
-         do update set last_seen_at = now()`,
-        [userId, isAllowed(userId)]
-      );
-
       if (text === "/id") {
         await sendTelegramMessage(chatId, `Telegram user_id của bạn là: ${userId}`);
-        continue;
-      }
-
-      if (!isAllowed(userId)) {
-        await sendTelegramMessage(chatId, "Bạn không có quyền sử dụng Hermes.");
-        continue;
-      }
-
-      if (text === "/health") {
-        await sendTelegramMessage(chatId, "Hermes app online ✅\nWorker sẽ xử lý task trong nền.");
         continue;
       }
 
@@ -1542,6 +1555,7 @@ NEXT ACTION:
   
 
 
+      console.log("DEFAULT_TASK_PATH_ENTERED", { userId, chatId, text });
       const taskId = await createTask(chatId, userId, text);
       await sendTelegramMessage(chatId, `Đã nhận task #${taskId}. Hermes đang xử lý...`);
     }


### PR DESCRIPTION
### Motivation
- `/start` messages were falling through the polling handler into the default task path and creating `hermes_tasks`, which triggers the heavy worker/AI flow unexpectedly. 
- The authorization check and simple command routing needed to run immediately after parsing `chatId`, `userId`, and `text` to short-circuit lightweight commands.

### Description
- Added early insertion into `telegram_users` and early authorization check right after parsing the incoming message in `index.js` so unauthorized users are denied and return immediately. 
- Implemented short-circuit handlers for `/start`, `/help`, and `/health` that send an immediate reply and `continue`, and added `console.log` entries `COMMAND_HANDLED /start`, `COMMAND_HANDLED /help`, and `COMMAND_HANDLED /health`. 
- Added `console.log("DEFAULT_TASK_PATH_ENTERED", { userId, chatId, text })` immediately before calling `createTask` so the default task path is explicitly logged and only reached after command routing. 
- Changes are limited to `index.js` only and minimize the diff without weakening allowlist/security logic. 

### Testing
- Ran `node --check index.js` to verify syntax and the file check passed successfully. 
- Verified code diff and commit locally to ensure only `index.js` changed and the routing/logging edits are present. 
- No other automated test suites were run as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f416ae82e08333a6acc260f55a7cd5)