### PR TITLE
Telegram approval UX, /approve handling, persist blocked-approval failures, and health SQL fix

### DIFF
--- a/dispatcher/health.js
+++ b/dispatcher/health.js
@@ -18,9 +18,9 @@ async function getSystemHealth() {
   );
   const oldest = await query(
     `select
-      extract(epoch from (now() - min(created_at)))::int filter (where status='pending') as oldest_pending_seconds,
-      extract(epoch from (now() - min(created_at)))::int filter (where status='pending_approval') as oldest_pending_approval_seconds
-     from hermes_tasks where status in ('pending','pending_approval')`,
+      coalesce(extract(epoch from (now() - min(case when status='pending' then created_at end)))::int, 0) as oldest_pending_seconds,
+      coalesce(extract(epoch from (now() - min(case when status='pending_approval' then created_at end)))::int, 0) as oldest_pending_approval_seconds
+     from hermes_tasks`,
   );
   const stuck = await query(
     `select count(*)::int as c from hermes_tasks where status='running' and heartbeat_at < now() - interval '10 minutes'`,

--- a/index.js
+++ b/index.js
@@ -681,6 +681,40 @@ async function createTask(chatId, userId, text) {
      values ($1, 'pending_approval', $2)`,
     [taskId, "Task requires explicit approval before running"]
     );
+    const actionList = Array.isArray(approvalSnapshot.action_list) ? approvalSnapshot.action_list.join(", ") : "-";
+    const shortHash = approvalSnapshotHash ? approvalSnapshotHash.slice(0, 12) : "-";
+    const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
+    const approvalMessage = [
+      `🛂 Task #${taskId} cần duyệt`,
+      `Intent: ${approvalSnapshot.intent || "-"}`,
+      `Input: ${String(text || "").slice(0, 500) || "-"}`,
+      `Risk: ${approvalSnapshot.risk_level || "-"}`,
+      `Expires: ${expiresAt}`,
+      `Snapshot: ${shortHash}`,
+      `Actions: ${actionList || "-"}`,
+    ].join("\n");
+    try {
+      await sendTelegramMessage(chatId, approvalMessage, {
+        reply_markup: {
+          inline_keyboard: [[
+            { text: "✅ Duyệt", callback_data: `approve_${taskId}` },
+            { text: "❌ Từ chối", callback_data: `reject_${taskId}` },
+          ]],
+        },
+      });
+      await query(
+        `insert into hermes_task_events (task_id, event_type, message)
+         values ($1, 'operator_notified', $2)`,
+        [taskId, "Approval request sent to operator"],
+      );
+    } catch (e) {
+      console.warn("[approval notify] failed", e.message);
+      await query(
+        `insert into hermes_task_events (task_id, event_type, message, payload)
+         values ($1, 'operator_notification_failed', $2, $3)`,
+        [taskId, "Failed to send approval request", { error: String(e.message || "").slice(0, 200) }],
+      );
+    }
   }
 
   return taskId;
@@ -697,6 +731,54 @@ async function shouldRateLimitApproval(taskId, userId, actionType) {
     [taskId, actionType, String(userId)],
   );
   return (r.rows[0]?.c || 0) > 0;
+}
+
+async function handleApprovalDecision({ taskId, actorUserId, chatId, action }) {
+  if (!Number.isInteger(taskId) || taskId <= 0) {
+    await sendTelegramMessage(chatId, "Dùng: /approve <id_số_nguyên_dương> hoặc /reject <id_số_nguyên_dương>");
+    return;
+  }
+  if (!isAllowed(actorUserId)) {
+    await sendTelegramMessage(chatId, `❌ Bạn không có quyền ${action === "approve" ? "duyệt" : "từ chối"} task ${taskId}`);
+    return;
+  }
+  const taskCheck = await query(
+    `select status, input_text, intent, approval_snapshot_hash, approval_snapshot_payload, approval_expires_at
+     from hermes_tasks where id=$1 limit 1`,
+    [taskId],
+  );
+  const t = taskCheck.rows[0];
+  if (!t) { await sendTelegramMessage(chatId, `⚠️ Task ${taskId} không tồn tại.`); return; }
+  if (t.status !== 'pending_approval') { await sendTelegramMessage(chatId, `ℹ️ Task ${taskId} đã được xử lý trước đó.`); return; }
+  if (t.approval_expires_at && new Date(t.approval_expires_at).getTime() < Date.now()) {
+    await query(`insert into hermes_task_events (task_id, event_type, message, payload) values ($1,'approval_expired',$2,$3)`, [taskId, 'Expired approval rejected', { callback_user_id: actorUserId }]);
+    await sendTelegramMessage(chatId, `⛔ Approval cho task ${taskId} đã hết hạn.`);
+    return;
+  }
+  const payload = t.approval_snapshot_payload || {};
+  payload.task_id = Number(taskId);
+  payload.intent = payload.intent || t.intent || "execute";
+  payload.normalized_input = String(t.input_text || "").trim().toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, " ").replace(/\s+/g, " ").trim();
+  payload.app_env = payload.app_env || (process.env.APP_ENV || "development");
+  const expectedHash = crypto.createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+  if (expectedHash !== t.approval_snapshot_hash) {
+    await query(`insert into hermes_task_events (task_id, event_type, message, payload) values ($1,'approval_snapshot_mismatch',$2,$3)`, [taskId, 'Approval rejected due to snapshot mismatch', { callback_user_id: actorUserId }]);
+    await sendTelegramMessage(chatId, `⛔ Task ${taskId} đã thay đổi, không thể ${action === "approve" ? "duyệt" : "từ chối"} theo snapshot cũ.`);
+    return;
+  }
+
+  if (action === "approve") {
+    const approved = await query(`update hermes_tasks set status='approved', approved_by=$2, approved_at=now(), updated_at=now() where id=$1 and status='pending_approval'`, [taskId, String(actorUserId)]);
+    if ((approved.rowCount || 0) !== 1) { await sendTelegramMessage(chatId, `⚠️ Task ${taskId} không ở trạng thái chờ duyệt.`); return; }
+    await query(`insert into hermes_task_events (task_id, event_type, message) values ($1, 'approved', $2)`, [taskId, "Task approved from Telegram"]);
+    await sendTelegramMessage(chatId, `✅ Đã duyệt task ${taskId}`);
+    return;
+  }
+  const rej = await query(`update hermes_tasks set status='failed', error_text='Rejected by operator', updated_at=now() where id=$1 and status='pending_approval'`, [taskId]);
+  if ((rej.rowCount || 0) === 1) {
+    await query(`insert into hermes_task_events (task_id, event_type, message, payload) values ($1,'rejected',$2,$3)`, [taskId, 'Task rejected from Telegram', { callback_user_id: actorUserId }]);
+  }
+  await sendTelegramMessage(chatId, `❌ Đã từ chối task ${taskId}`);
 }
 
 async function createCodeAgentTask(chatId, userId, taskText) {
@@ -955,85 +1037,17 @@ if (callback) {
   }
 
   if (data.startsWith("approve_")) {
-    const taskId = data.split("_")[1];
+    const taskId = Number(data.split("_")[1]);
     if (await shouldRateLimitApproval(taskId, callbackUserId, 'approval_rate_limited')) {
       await sendTelegramMessage(chatId, "⏳ Thao tác quá nhanh, vui lòng đợi vài giây.");
       continue;
     }
-    if (!isAllowed(callbackUserId)) {
-      await query(
-        `insert into hermes_task_events (task_id, event_type, message, payload)
-         values ($1, 'approval_rejected', $2, $3)`,
-        [taskId, 'Unauthorized approval callback blocked', { callback_user_id: callbackUserId }],
-      );
-      await sendTelegramMessage(chatId, `❌ Bạn không có quyền duyệt task ${taskId}`);
-      continue;
-    }
-    const taskCheck = await query(
-      `select status, input_text, intent, telegram_chat_id, telegram_user_id, approval_snapshot_hash, approval_snapshot_payload, approval_expires_at
-       from hermes_tasks where id=$1 limit 1`,
-      [taskId],
-    );
-    const t = taskCheck.rows[0];
-    if (!t) {
-      await sendTelegramMessage(chatId, `⚠️ Task ${taskId} không tồn tại.`);
-      continue;
-    }
-    if (t.status !== 'pending_approval') {
-      await sendTelegramMessage(chatId, `ℹ️ Task ${taskId} đã được xử lý trước đó.`);
-      continue;
-    }
-    if (t.approval_expires_at && new Date(t.approval_expires_at).getTime() < Date.now()) {
-      await sendTelegramMessage(chatId, `⛔ Approval cho task ${taskId} đã hết hạn.`);
-      await query(`insert into hermes_task_events (task_id, event_type, message, payload) values ($1,'approval_expired',$2,$3)`, [taskId, 'Expired approval rejected', { callback_user_id: callbackUserId }]);
-      continue;
-    }
-    const payload = t.approval_snapshot_payload || {};
-    payload.task_id = Number(taskId);
-    payload.intent = payload.intent || t.intent || "execute";
-    payload.normalized_input = String(t.input_text || "").trim().toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, " ").replace(/\s+/g, " ").trim();
-    payload.app_env = payload.app_env || (process.env.APP_ENV || "development");
-    const expectedHash = crypto.createHash("sha256").update(JSON.stringify(payload)).digest("hex");
-    if (expectedHash !== t.approval_snapshot_hash) {
-      await sendTelegramMessage(chatId, `⛔ Task ${taskId} đã thay đổi, từ chối duyệt.`);
-      await query(`insert into hermes_task_events (task_id, event_type, message, payload) values ($1,'approval_snapshot_mismatch',$2,$3)`, [taskId, 'Approval rejected due to snapshot mismatch', { callback_user_id: callbackUserId }]);
-      continue;
-    }
-    const approved = await query(
-      `update hermes_tasks
-       set status='approved', approved_by=$2, approved_at=now(), updated_at=now()
-       where id=$1 and status='pending_approval'`,
-      [taskId, String(callbackUserId)],
-    );
-    if ((approved.rowCount || 0) !== 1) {
-      await sendTelegramMessage(chatId, `⚠️ Task ${taskId} không ở trạng thái chờ duyệt.`);
-      continue;
-    }
-    await query(
-      `insert into hermes_task_events (task_id, event_type, message)
-       values ($1, 'approved', $2)`,
-      [taskId, "Task approved from Telegram callback"],
-    );
-
-    await sendTelegramMessage(chatId, `Đã duyệt task ${taskId}`);
-
-    await handleAction(`duyệt task ${taskId}`, chatId);
+    await handleApprovalDecision({ taskId, actorUserId: callbackUserId, chatId, action: "approve" });
   }
 
   if (data.startsWith("reject_")) {
-    const taskId = data.split("_")[1];
-    if (!isAllowed(callbackUserId)) {
-      await sendTelegramMessage(chatId, `❌ Bạn không có quyền từ chối task ${taskId}`);
-      continue;
-    }
-    const rej = await query(`update hermes_tasks set status='failed', error_text='Rejected by operator', updated_at=now() where id=$1 and status='pending_approval'`, [taskId]);
-    if ((rej.rowCount || 0) === 1) {
-      await query(`insert into hermes_task_events (task_id, event_type, message, payload) values ($1,'rejected',$2,$3)`, [taskId, 'Task rejected from Telegram callback', { callback_user_id: callbackUserId }]);
-    }
-
-    await sendTelegramMessage(chatId, `Đã từ chối task ${taskId}`);
-
-    await handleAction(`từ chối task ${taskId}`, chatId);
+    const taskId = Number(data.split("_")[1]);
+    await handleApprovalDecision({ taskId, actorUserId: callbackUserId, chatId, action: "reject" });
   }
   if (data.startsWith("details_")) {
     const taskId = data.split("_")[1];
@@ -1111,6 +1125,18 @@ if (callback) {
         }
         const msg = ev.rows.map((e,i)=>`${i+1+offsetArg}. ${new Date(e.created_at).toISOString()} — ${e.event_type}\n   ${String(e.message||'').slice(0,120)}`).join("\n\n") || "Không có event.";
         await sendTelegramMessage(chatId, `🧾 Events for task #${id}\n\n${msg}`);
+        continue;
+      }
+      if (normalized.startsWith("/approve")) {
+        const id = Number(text.split(/\s+/)[1]);
+        if (!Number.isInteger(id) || id <= 0) { await sendTelegramMessage(chatId, "Dùng: /approve <id_số_nguyên_dương>"); continue; }
+        await handleApprovalDecision({ taskId: id, actorUserId: userId, chatId, action: "approve" });
+        continue;
+      }
+      if (normalized.startsWith("/reject")) {
+        const id = Number(text.split(/\s+/)[1]);
+        if (!Number.isInteger(id) || id <= 0) { await sendTelegramMessage(chatId, "Dùng: /reject <id_số_nguyên_dương>"); continue; }
+        await handleApprovalDecision({ taskId: id, actorUserId: userId, chatId, action: "reject" });
         continue;
       }
 

--- a/worker.js
+++ b/worker.js
@@ -125,6 +125,36 @@ async function safeNotifyOperator(task, stage, message, metadata = {}) {
   }
 }
 
+async function persistBlockedApprovalFailure(task, safeError, approvalStatus) {
+  const summary = {
+    task_id: task.id,
+    final_status: "failed",
+    intent: task.intent || "execute",
+    approval_status: approvalStatus,
+    actions_attempted: 0,
+    actions_succeeded: 0,
+    actions_failed: 0,
+    actions: [],
+    key_output: null,
+    safe_error: safeError,
+    next_operator_action: "Tạo lại task và duyệt lại trong thời hạn.",
+    confidence_level: "low",
+  };
+  await query(
+    `update hermes_tasks
+     set status='failed',
+         error_text=$2,
+         result_summary=$3::jsonb,
+         execution_completed_at=now(),
+         duration_ms=greatest(0, extract(epoch from (now() - coalesce(execution_started_at, now()))) * 1000)::int,
+         updated_at=now()
+     where id=$1`,
+    [task.id, safeError, JSON.stringify(summary)],
+  );
+  await event(task.id, "failed", safeError, summary);
+  await safeNotifyOperator(task, safeError, `❌ Task #${task.id} failed: ${safeError}\n${JSON.stringify(summary)}`);
+}
+
 async function logAction(taskId, actionName, input, output, status) {
   await query(
     `insert into hermes_action_logs (task_id, action_name, input, output, status)
@@ -1146,6 +1176,7 @@ async function processOneTask() {
     if (calcHash !== approvalTask.approval_snapshot_hash) {
       await event(task.id, "approval_invalidated", "Approval snapshot mismatch before execution");
       await safeNotifyOperator(task, 'approval_invalidated', `🛑 Task #${task.id}: Approval không còn hợp lệ do task context đã thay đổi.`);
+      await persistBlockedApprovalFailure(task, "approval_invalidated", "invalidated");
       await failTask(task.id, WORKER_ID, "approval_invalidated", false);
       return;
     }
@@ -1155,6 +1186,7 @@ async function processOneTask() {
     if (!expiry || now >= expiry || !approvedAt || approvedAt >= expiry) {
       await event(task.id, "approval_expired_before_execution", "Approval expired or invalid timing before execution");
       await safeNotifyOperator(task, 'approval_expired_before_execution', `🛑 Task #${task.id}: Approval đã hết hạn, không thực thi.`);
+      await persistBlockedApprovalFailure(task, "approval_expired_before_execution", "expired");
       await failTask(task.id, WORKER_ID, "approval_expired_before_execution", false);
       return;
     }


### PR DESCRIPTION
### Motivation
- Fix missing inline approve/reject buttons so operators can act on `pending_approval` tasks sent from Telegram. 
- Prevent `/approve` and `/reject` text commands from being treated as task creation and centralize approval checks. 
- Ensure blocked execution due to invalidated/expired approvals persists a safe failure summary and timing metadata. 
- Replace fragile health SQL that used invalid filter/cast usage with a PostgreSQL-safe aggregate expression.

### Description
- Send a structured operator approval message when a task transitions to `pending_approval` in `createTask` (includes task id, intent, input, risk, expiry, short snapshot hash, actions) and attach inline keyboard buttons `approve_<id>` and `reject_<id>`; on send failure emit `operator_notification_failed` and log a warning (`index.js`).
- Add a centralized approval handler `handleApprovalDecision(...)` that validates positive integer id, operator permission, `pending_approval` status, expiry, and snapshot hash; wired callback handlers (`approve_*/reject_*`) and new text commands `/approve <id>` and `/reject <id>` to reuse the same logic and update task status/events safely (`index.js`).
- Add `persistBlockedApprovalFailure(...)` in `worker.js` and call it before failing a task when approval is invalidated or expired, ensuring the task row receives `status='failed'`, safe `error_text`, `result_summary` JSON in the required shape, `execution_completed_at`, and a non-negative `duration_ms`, and emit a final `failed` event and best-effort operator notification.
- Update `dispatcher/health.js` to compute oldest pending ages using `min(case when ...)` with `coalesce` to avoid unsupported `::int filter (...)` SQL patterns and make the health query PostgreSQL-safe.
- All notification sends are best-effort and non-fatal (they log and emit events on failure rather than crashing).

### Testing
- Ran syntax checks: `node -c index.js`, `node -c worker.js`, and `node -c dispatcher/health.js` and all checks succeeded.
- No automated unit tests available; changes were limited to runtime behavior and SQL query form to minimize scope and preserve approval security.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d520e1848333b2023ec991af3af2)