### PR TITLE
Canonicalize approval snapshot payloads to fix hash drift

### DIFF
--- a/approvalSnapshot.js
+++ b/approvalSnapshot.js
@@ -1,0 +1,54 @@
+const crypto = require('crypto');
+
+function normalizeInputText(inputText) {
+  return String(inputText || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function toStringArray(value) {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => String(item));
+}
+
+function sortKeysDeep(value) {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (!value || typeof value !== 'object') return value;
+  const sorted = {};
+  for (const key of Object.keys(value).sort()) {
+    sorted[key] = sortKeysDeep(value[key]);
+  }
+  return sorted;
+}
+
+function canonicalizeApprovalSnapshot({ taskId, payload, inputText, intent, appEnv }) {
+  const source = payload && typeof payload === 'object' ? payload : {};
+  const canonical = {
+    action_list: toStringArray(source.action_list),
+    app_env: String(source.app_env || appEnv || 'development'),
+    execution_plan: toStringArray(source.execution_plan),
+    intent: String(source.intent || intent || ''),
+    memory_ids_used: toStringArray(source.memory_ids_used),
+    normalized_input: String(source.normalized_input || normalizeInputText(inputText)),
+    risk_level: String(source.risk_level || 'unknown'),
+    task_id: String(taskId),
+  };
+  return sortKeysDeep(canonical);
+}
+
+function hashApprovalSnapshot(canonicalPayload) {
+  return crypto
+    .createHash('sha256')
+    .update(JSON.stringify(sortKeysDeep(canonicalPayload)))
+    .digest('hex');
+}
+
+module.exports = {
+  canonicalizeApprovalSnapshot,
+  hashApprovalSnapshot,
+  normalizeInputText,
+  sortKeysDeep,
+};

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const axios = require("axios");
 const { query } = require("./db");
-const crypto = require("crypto");
+const { canonicalizeApprovalSnapshot, hashApprovalSnapshot, normalizeInputText } = require("./approvalSnapshot");
 const { getSystemHealth } = require("./dispatcher/health");
 const {
   ensureGBrainSchema,
@@ -619,26 +619,25 @@ function isAllowed(userId) {
 
 
 async function createTask(chatId, userId, text) {
-  const normalized = String(text || "")
-    .trim()
-    .toLowerCase()
-    .replace(/[^\p{L}\p{N}\s]/gu, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+  const normalized = normalizeInputText(text);
   const dedupeKey = crypto
     .createHash("sha256")
     .update(`${userId}:${normalized}`)
     .digest("hex");
-  const approvalSnapshot = {
-    task_id: null,
+  const approvalSnapshot = canonicalizeApprovalSnapshot({
+    taskId: "",
+    payload: {
+      intent: "execute",
+      normalized_input: normalized,
+      execution_plan: ["parse_intent", "run_gates", "execute_plan"],
+      risk_level: "medium",
+      action_list: ["git status", "npm test", "npm run build"],
+      memory_ids_used: [],
+    },
+    inputText: text,
     intent: "execute",
-    normalized_input: normalized,
-    execution_plan: ["parse_intent", "run_gates", "execute_plan"],
-    risk_level: "medium",
-    action_list: ["git status", "npm test", "npm run build"],
-    app_env: process.env.APP_ENV || "development",
-    memory_ids_used: [],
-  };
+    appEnv: process.env.APP_ENV || "development",
+  });
 
   const result = await query(
     `insert into hermes_tasks (telegram_chat_id, telegram_user_id, input_text, status, idempotency_key)
@@ -649,11 +648,14 @@ async function createTask(chatId, userId, text) {
   );
 
   const taskId = result.rows[0].id;
-  approvalSnapshot.task_id = taskId;
-  const approvalSnapshotHash = crypto
-    .createHash("sha256")
-    .update(JSON.stringify(approvalSnapshot))
-    .digest("hex");
+  const canonicalApprovalSnapshot = canonicalizeApprovalSnapshot({
+    taskId,
+    payload: approvalSnapshot,
+    inputText: text,
+    intent: "execute",
+    appEnv: process.env.APP_ENV || "development",
+  });
+  const approvalSnapshotHash = hashApprovalSnapshot(canonicalApprovalSnapshot);
 
   await query(
     `insert into hermes_task_events (task_id, event_type, message)
@@ -673,7 +675,7 @@ async function createTask(chatId, userId, text) {
          approval_expires_at=now()+interval '15 minutes',
          updated_at=now()
      where id=$1 and status='planned'`,
-    [taskId, approvalSnapshotHash, JSON.stringify(approvalSnapshot)],
+    [taskId, approvalSnapshotHash, JSON.stringify(canonicalApprovalSnapshot)],
   );
   if ((plannedToPending.rowCount || 0) === 1) {
     await query(
@@ -755,14 +757,16 @@ async function handleApprovalDecision({ taskId, actorUserId, chatId, action }) {
     await sendTelegramMessage(chatId, `⛔ Approval cho task ${taskId} đã hết hạn.`);
     return;
   }
-  const payload = t.approval_snapshot_payload || {};
-  payload.task_id = Number(taskId);
-  payload.intent = payload.intent || t.intent || "execute";
-  payload.normalized_input = String(t.input_text || "").trim().toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, " ").replace(/\s+/g, " ").trim();
-  payload.app_env = payload.app_env || (process.env.APP_ENV || "development");
-  const expectedHash = crypto.createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+  const canonicalPayload = canonicalizeApprovalSnapshot({
+    taskId,
+    payload: t.approval_snapshot_payload || {},
+    inputText: t.input_text,
+    intent: t.intent || "execute",
+    appEnv: process.env.APP_ENV || "development",
+  });
+  const expectedHash = hashApprovalSnapshot(canonicalPayload);
   if (expectedHash !== t.approval_snapshot_hash) {
-    await query(`insert into hermes_task_events (task_id, event_type, message, payload) values ($1,'approval_snapshot_mismatch',$2,$3)`, [taskId, 'Approval rejected due to snapshot mismatch', { callback_user_id: actorUserId }]);
+    await query(`insert into hermes_task_events (task_id, event_type, message, payload) values ($1,'approval_snapshot_mismatch',$2,$3)`, [taskId, 'Approval rejected due to snapshot mismatch', { callback_user_id: actorUserId, stored_hash_short: String(t.approval_snapshot_hash || '').slice(0, 12), recomputed_hash_short: String(expectedHash || '').slice(0, 12), stored_task_id_type: typeof (t.approval_snapshot_payload || {}).task_id, canonical_task_id_type: typeof canonicalPayload.task_id }]);
     await sendTelegramMessage(chatId, `⛔ Task ${taskId} đã thay đổi, không thể ${action === "approve" ? "duyệt" : "từ chối"} theo snapshot cũ.`);
     return;
   }

--- a/worker.js
+++ b/worker.js
@@ -18,7 +18,7 @@ const { executePlan } = require('./dispatcher/executor');
 const { runDueGoals } = require('./dispatcher/goalRunner');
 
 const rawExecAsync = promisify(exec);
-const crypto = require("crypto");
+const { canonicalizeApprovalSnapshot, hashApprovalSnapshot } = require('./approvalSnapshot');
 
 async function execAsync(command, options = {}) {
   const decision = shouldRequireApproval(command, envConfig.HERMES_ENV);
@@ -1167,14 +1167,21 @@ async function processOneTask() {
       [task.id],
     );
     const approvalTask = approvalRes.rows[0];
-    const snapshotPayload = approvalTask?.approval_snapshot_payload || {};
-    snapshotPayload.task_id = Number(task.id);
-    snapshotPayload.intent = snapshotPayload.intent || approvalTask.intent || 'execute';
-    snapshotPayload.normalized_input = String(approvalTask.input_text || '').trim().toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, ' ').replace(/\s+/g, ' ').trim();
-    snapshotPayload.app_env = snapshotPayload.app_env || (process.env.APP_ENV || 'development');
-    const calcHash = crypto.createHash('sha256').update(JSON.stringify(snapshotPayload)).digest('hex');
+    const canonicalSnapshotPayload = canonicalizeApprovalSnapshot({
+      taskId: task.id,
+      payload: approvalTask?.approval_snapshot_payload || {},
+      inputText: approvalTask?.input_text,
+      intent: approvalTask?.intent || 'execute',
+      appEnv: process.env.APP_ENV || 'development',
+    });
+    const calcHash = hashApprovalSnapshot(canonicalSnapshotPayload);
     if (calcHash !== approvalTask.approval_snapshot_hash) {
-      await event(task.id, "approval_invalidated", "Approval snapshot mismatch before execution");
+      await event(task.id, "approval_invalidated", "Approval snapshot mismatch before execution", {
+        stored_hash_short: String(approvalTask.approval_snapshot_hash || '').slice(0, 12),
+        recomputed_hash_short: String(calcHash || '').slice(0, 12),
+        stored_task_id_type: typeof (approvalTask?.approval_snapshot_payload || {}).task_id,
+        canonical_task_id_type: typeof canonicalSnapshotPayload.task_id,
+      });
       await safeNotifyOperator(task, 'approval_invalidated', `🛑 Task #${task.id}: Approval không còn hợp lệ do task context đã thay đổi.`);
       await persistBlockedApprovalFailure(task, "approval_invalidated", "invalidated");
       await failTask(task.id, WORKER_ID, "approval_invalidated", false);


### PR DESCRIPTION
### Motivation
- Snapshot validation was failing because `task_id` and other fields could have different JS types (e.g. stored string vs recomputed number), and JSON hashing is type-sensitive. 
- The mismatch caused fresh approvals to be rejected even when the logical snapshot was unchanged. 
- The fix must keep strict snapshot validation while ensuring deterministic, type-stable hashing across creation, approval, and worker execution. 

### Description
- Added `approvalSnapshot.js` with `canonicalizeApprovalSnapshot` and `hashApprovalSnapshot` to normalize snapshot fields, enforce `task_id` as `String`, coerce arrays to string arrays, normalize `normalized_input`, provide `app_env` and `risk_level` defaults, and recursively sort object keys for stable JSON output. 
- Updated `createTask()` in `index.js` to build the canonical payload and store `approval_snapshot_payload` as the canonical JSON and `approval_snapshot_hash` from `hashApprovalSnapshot`. 
- Updated `handleApprovalDecision()` in `index.js` to recompute the canonical payload via the shared helper and compare hashes (instead of ad-hoc mutation), and to emit diagnostics (`stored_hash_short`, `recomputed_hash_short`, `stored_task_id_type`, `canonical_task_id_type`) on mismatch while preserving the friendly Telegram error. 
- Updated worker approval gate (`processOneTask()` in `worker.js`) to use the same canonicalization + hashing path and to add the same mismatch diagnostics before failing execution. 

### Testing
- Ran static checks: `node -c index.js` succeeded. 
- Ran static checks: `node -c worker.js` succeeded. 
- End-to-end Telegram/DB approval flow and manual tamper tests were not executed in this environment, so runtime verification (create pending approval → immediate `/approve <id>` and DB tamper rejection) should be performed in integration testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e0965d208333bebd339b579adfa7)