### PR TITLE
Guard Telegram small-talk and unknown input from task execution path

### DIFF
--- a/index.js
+++ b/index.js
@@ -614,6 +614,68 @@ NEXT ACTION:
 - Review → /review <kết quả>`;
 }
 
+
+const CASUAL_TELEGRAM_INPUTS = new Set([
+  "hi",
+  "hello",
+  "hey",
+  "chào",
+  "chao",
+  "xin chào",
+  "xin chao",
+  "alo",
+  "test",
+  "ping",
+  "ok",
+]);
+
+const TASK_LIKE_TELEGRAM_PATTERNS = [
+  /^(git|gh|npm|pnpm|yarn|node|docker|kubectl)\b/i,
+  /^(kiểm tra|kiem tra|check|xem|chạy|chay|run)\b.*\b(health|status|test|build|deploy|log|logs)\b/i,
+  /^(tạo|tao|create|mở|mo|open)\b.*\b(issue|ticket|task|bug|pr|pull request)\b/i,
+  /\b(health check|repo status|branch status|run build|run test)\b/i,
+];
+
+function normalizeTelegramIntentText(text) {
+  return String(text || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[!?.。！？]+$/g, "")
+    .replace(/\s+/g, " ");
+}
+
+function isCasualTelegramInput(text) {
+  return CASUAL_TELEGRAM_INPUTS.has(normalizeTelegramIntentText(text));
+}
+
+function isTaskLikeTelegramInput(text) {
+  const normalizedIntentText = normalizeTelegramIntentText(text);
+  return TASK_LIKE_TELEGRAM_PATTERNS.some((pattern) => pattern.test(normalizedIntentText));
+}
+
+function buildCasualTelegramReply() {
+  return [
+    "👋 Chào bạn! Hermes đang sẵn sàng hỗ trợ.",
+    "",
+    "Mình có thể giúp:",
+    "- Kiểm tra repo/health: git status, kiểm tra health",
+    "- Chạy build/test có duyệt an toàn: npm run build",
+    "- Tạo issue hoặc chuẩn bị prompt Codex: /code <task>, /codex <task>",
+    "- Audit/review/recall memory: /audit, /review, /recall",
+    "",
+    "Gõ /commands hoặc /menu để xem thêm lệnh.",
+  ].join("\n");
+}
+
+function buildUnknownTelegramReply(text) {
+  return [
+    `Mình chưa rõ bạn muốn Hermes làm gì với: "${String(text || "").slice(0, 120)}"`,
+    "",
+    "Bạn muốn mình kiểm tra, build/test, tạo issue, audit, hay chỉ chat?",
+    "Ví dụ: git status, npm run build, kiểm tra health, tạo issue <nội dung>.",
+  ].join("\n");
+}
+
 function isAllowed(userId) {
   return ALLOWED_USER_IDS.includes(Number(userId));
 }
@@ -1775,6 +1837,18 @@ NEXT ACTION:
 }
   
 
+
+      if (isCasualTelegramInput(text)) {
+        console.log("CASUAL_CHAT_HANDLED", { userId, chatId, text });
+        await sendTelegramMessage(chatId, buildCasualTelegramReply());
+        continue;
+      }
+
+      if (!isTaskLikeTelegramInput(text)) {
+        console.log("UNKNOWN_INTENT_CLARIFICATION", { userId, chatId, text });
+        await sendTelegramMessage(chatId, buildUnknownTelegramReply(text));
+        continue;
+      }
 
       console.log("DEFAULT_TASK_PATH_ENTERED", { userId, chatId, text });
       const taskId = await createTask(chatId, userId, text);


### PR DESCRIPTION
### Motivation
- Prevent casual greetings and short chit-chat (e.g. "hi", "chào", "ping", "ok") from being enqueued as executable tasks and creating `hermes_tasks` rows.
- Ensure the Telegram intake path asks for clarification on ambiguous free-form input instead of defaulting to an execution intent/approval flow.
- Keep existing command handling (including `/start`) and approval snapshot/DB schema/worker gates unchanged.

### Description
- Added a set of casual inputs in `index.js` (`CASUAL_TELEGRAM_INPUTS`) and a small set of `TASK_LIKE_TELEGRAM_PATTERNS` regexes to identify real command-like inputs. 
- Implemented `normalizeTelegramIntentText`, `isCasualTelegramInput`, and `isTaskLikeTelegramInput` helper functions and two reply builders: `buildCasualTelegramReply` and `buildUnknownTelegramReply`.
- Inserted an early-return guard in the Telegram polling loop before the default task path so casual inputs receive a friendly reply and unknown inputs receive a clarification request; only `task-like` inputs proceed to `createTask(...)`. 
- Did not modify DB schema, approval snapshot hashing, worker execution gates, or weaken approval safety; `/start` and existing explicit command branches remain unchanged.

### Testing
- Ran `node --check index.js` to validate syntax and static correctness, which succeeded.
- Ran `git diff --check` to ensure no whitespace/diff issues, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff47020ecc833390dd671c0c1d165c)