### PR TITLE
Add Hermes operator commands and fix crypto hashing

### DIFF
--- a/approvalSnapshot.js
+++ b/approvalSnapshot.js
@@ -1,4 +1,4 @@
-const crypto = require('crypto');
+const nodeCrypto = require('node:crypto');
 
 function normalizeInputText(inputText) {
   return String(inputText || '')
@@ -40,7 +40,7 @@ function canonicalizeApprovalSnapshot({ taskId, payload, inputText, intent, appE
 }
 
 function hashApprovalSnapshot(canonicalPayload) {
-  return crypto
+  return nodeCrypto
     .createHash('sha256')
     .update(JSON.stringify(sortKeysDeep(canonicalPayload)))
     .digest('hex');

--- a/dispatcher/approval.ts
+++ b/dispatcher/approval.ts
@@ -1,10 +1,10 @@
-import * as crypto from 'crypto';
+import * as nodeCrypto from 'crypto';
 import { logEvent } from './events';
 import { validateTransition } from './fsm';
 import { Queryable, TaskStatus } from './types';
 
 function hashPayload(payload: unknown): string {
-  return crypto.createHash('sha256').update(JSON.stringify(payload || {})).digest('hex');
+  return nodeCrypto.createHash('sha256').update(JSON.stringify(payload || {})).digest('hex');
 }
 
 async function updateStatusTx(db: Queryable, taskId: number, from: TaskStatus, to: TaskStatus): Promise<void> {
@@ -14,7 +14,7 @@ async function updateStatusTx(db: Queryable, taskId: number, from: TaskStatus, t
 }
 
 export async function createCommandApproval(db: Queryable, taskId: number, actionType: string, riskLevel: string, payload: unknown = {}): Promise<string> {
-  const token = crypto.randomBytes(16).toString('hex');
+  const token = nodeCrypto.randomBytes(16).toString('hex');
   const payloadHash = hashPayload(payload);
   await db.query(
     `insert into hermes_approvals (task_id,status,action_type,risk_level,approval_token,expires_at,payload_hash)

--- a/dispatcher/health.js
+++ b/dispatcher/health.js
@@ -1,70 +1,119 @@
 const { query } = require('../db');
 const envConfig = require('../config/env');
 
-async function getSystemHealth() {
-  let dbOk = true;
+async function safeQuery(sql, params = []) {
   try {
-    await query('select 1');
-  } catch {
-    dbOk = false;
+    const result = await query(sql, params);
+    return { ok: true, rows: result.rows || [] };
+  } catch (error) {
+    return { ok: false, rows: [], error: error.message };
   }
+}
 
-  const worker = await query(
-    `select worker_id,last_heartbeat_at,status
-     from hermes_worker_status
-     order by last_heartbeat_at desc
-     limit 1`
-  );
+async function getSystemHealth() {
+  const warnings = [];
+
+  const dbPing = await safeQuery('select 1');
+  const dbOk = dbPing.ok;
+  if (!dbOk) warnings.push(`DB ping failed: ${dbPing.error}`);
+
+  const worker = dbOk
+    ? await safeQuery(
+        `select worker_id,last_heartbeat_at,status
+         from hermes_worker_status
+         order by last_heartbeat_at desc
+         limit 1`,
+      )
+    : { ok: false, rows: [], error: dbPing.error };
+  if (!worker.ok) warnings.push(`Worker status unavailable: ${worker.error}`);
   const latestWorker = worker.rows[0] || null;
 
-  const q = await query(
-    `select
-      coalesce(sum(case when status='pending' then 1 else 0 end), 0)::int as pending,
-      coalesce(sum(case when status='running' then 1 else 0 end), 0)::int as running,
-      coalesce(sum(case when status='failed' then 1 else 0 end), 0)::int as failed,
-      coalesce(sum(case when status='pending_approval' then 1 else 0 end), 0)::int as waiting_approval
-     from hermes_tasks`
-  );
+  const queue = dbOk
+    ? await safeQuery(
+        `select
+          coalesce(sum(case when status='pending' then 1 else 0 end), 0)::int as pending,
+          coalesce(sum(case when status='planned' then 1 else 0 end), 0)::int as planned,
+          coalesce(sum(case when status='pending_approval' then 1 else 0 end), 0)::int as pending_approval,
+          coalesce(sum(case when status='approved' then 1 else 0 end), 0)::int as approved,
+          coalesce(sum(case when status='running' then 1 else 0 end), 0)::int as running,
+          coalesce(sum(case when status='completed' and updated_at >= now() - interval '24 hours' then 1 else 0 end), 0)::int as completed_24h,
+          coalesce(sum(case when status='failed' and updated_at >= now() - interval '24 hours' then 1 else 0 end), 0)::int as failed_24h,
+          coalesce(sum(case when status='failed' then 1 else 0 end), 0)::int as failed_total
+         from hermes_tasks`,
+      )
+    : { ok: false, rows: [], error: dbPing.error };
+  if (!queue.ok) warnings.push(`Queue counts unavailable: ${queue.error}`);
 
-  const oldest = await query(
-    `select
-      coalesce(extract(epoch from (now() - min(case when status='pending' then created_at end)))::int, 0) as oldest_pending_seconds,
-      coalesce(extract(epoch from (now() - min(case when status='pending_approval' then created_at end)))::int, 0) as oldest_pending_approval_seconds
-     from hermes_tasks
-     where status in ('pending','pending_approval')`
-  );
+  const oldest = dbOk
+    ? await safeQuery(
+        `select
+          coalesce(extract(epoch from (now() - min(case when status='pending' then created_at end)))::int, 0) as oldest_pending_seconds,
+          coalesce(extract(epoch from (now() - min(case when status='pending_approval' then created_at end)))::int, 0) as oldest_pending_approval_seconds
+         from hermes_tasks
+         where status in ('pending','pending_approval')`,
+      )
+    : { ok: false, rows: [], error: dbPing.error };
+  if (!oldest.ok) warnings.push(`Queue age unavailable: ${oldest.error}`);
 
-  const stuck = await query(
-    `select count(*)::int as c
-     from hermes_tasks
-     where status='running'
-       and heartbeat_at < now() - interval '10 minutes'`
-  );
+  const stuck = dbOk
+    ? await safeQuery(
+        `select count(*)::int as c
+         from hermes_tasks
+         where status='running'
+           and heartbeat_at < now() - interval '10 minutes'`,
+      )
+    : { ok: false, rows: [], error: dbPing.error };
+  if (!stuck.ok) warnings.push(`Stuck running count unavailable: ${stuck.error}`);
 
-  const m = await query(`select count(*)::int as total from hermes_memories`);
+  const latestTask = dbOk
+    ? await safeQuery(
+        `select id,status,intent,input_text,created_at,updated_at
+         from hermes_tasks
+         order by id desc
+         limit 1`,
+      )
+    : { ok: false, rows: [], error: dbPing.error };
+  if (!latestTask.ok) warnings.push(`Latest task unavailable: ${latestTask.error}`);
 
-  const running = q.rows[0]?.running || 0;
-  const status = !dbOk ? 'down' : running > 50 ? 'degraded' : 'ok';
+  const memory = dbOk
+    ? await safeQuery(`select count(*)::int as total from hermes_memories`)
+    : { ok: false, rows: [], error: dbPing.error };
+  if (!memory.ok) warnings.push(`Memory count unavailable: ${memory.error}`);
+
+  const q = queue.rows[0] || {};
+  const running = q.running || 0;
+  const status = !dbOk ? 'down' : running > 50 || warnings.length ? 'degraded' : 'ok';
 
   return {
     status,
+    app: { ok: true },
+    app_env: process.env.APP_ENV || 'development',
     env: envConfig.HERMES_ENV,
-    db: { ok: dbOk },
+    projectRoot: process.env.PROJECT_ROOT || process.cwd(),
+    db: { ok: dbOk, error: dbOk ? null : dbPing.error },
     worker: {
       alive: Boolean(latestWorker && latestWorker.last_heartbeat_at),
+      worker_id: latestWorker?.worker_id || null,
       last_heartbeat_at: latestWorker?.last_heartbeat_at || null,
       status: latestWorker?.status || null,
     },
     queue: {
-      pending: q.rows[0]?.pending || 0,
+      pending: q.pending || 0,
+      planned: q.planned || 0,
+      pending_approval: q.pending_approval || 0,
+      waiting_approval: q.pending_approval || 0,
+      approved: q.approved || 0,
       running,
-      failed: q.rows[0]?.failed || 0,
-      waiting_approval: q.rows[0]?.waiting_approval || 0,
+      completed_24h: q.completed_24h || 0,
+      failed_24h: q.failed_24h || 0,
+      failed: q.failed_total || 0,
       oldest_pending_seconds: oldest.rows[0]?.oldest_pending_seconds || 0,
       oldest_pending_approval_seconds: oldest.rows[0]?.oldest_pending_approval_seconds || 0,
       stuck_running: stuck.rows[0]?.c || 0,
     },
-    memory: { total: m.rows[0]?.total || 0 },
+    latest_task: latestTask.rows[0] || null,
+    memory: { total: memory.rows[0]?.total || 0 },
+    warnings,
   };
 }
 

--- a/dispatcher/idempotency.js
+++ b/dispatcher/idempotency.js
@@ -1,4 +1,4 @@
-const crypto = require('crypto');
+const nodeCrypto = require('node:crypto');
 const { query } = require('../db');
 
 function stableStringify(obj) {
@@ -8,7 +8,7 @@ function stableStringify(obj) {
 }
 
 function hashPayload(payload) {
-  return crypto.createHash('sha256').update(stableStringify(payload || {})).digest('hex');
+  return nodeCrypto.createHash('sha256').update(stableStringify(payload || {})).digest('hex');
 }
 
 async function getExistingIdempotentAction(key) {

--- a/gbrain.js
+++ b/gbrain.js
@@ -218,6 +218,77 @@ async function recallStructuredMemories(memoryType) {
     return true;
   });
 }
+
+async function rememberOperatorMemory(text, source = "telegram_operator") {
+  const memoryText = String(text || "").trim();
+  if (!memoryText) {
+    throw new Error("Memory text is required");
+  }
+
+  const lower = memoryText.toLowerCase();
+  let memoryType = "project_context";
+  if (lower.includes("deploy") || lower.includes("docker") || lower.includes("env")) {
+    memoryType = "deployment_rule";
+  } else if (lower.includes("approval") || lower.includes("command") || lower.includes("operator")) {
+    memoryType = "ops_sop";
+  } else if (lower.includes("bug") || lower.includes("error") || lower.includes("fail")) {
+    memoryType = "known_bug";
+  } else if (lower.includes("code") || lower.includes("test") || lower.includes("lint")) {
+    memoryType = "coding_rule";
+  }
+
+  const memoryKey = memoryText.split(/\s+/).slice(0, 8).join(" ").toLowerCase();
+  const result = await query(
+    `insert into hermes_memories (memory_key, memory_text, source, memory_type, importance, confidence)
+     values ($1, $2, $3, $4, 3, 0.8)
+     returning id, memory_key, memory_text, memory_type, created_at`,
+    [memoryKey, memoryText, source, memoryType],
+  );
+
+  return result.rows[0];
+}
+
+async function recallOperatorMemories(searchText, limit = 5) {
+  const keyword = String(searchText || "").trim();
+  if (!keyword) return [];
+  const terms = keyword.split(/\s+/).filter(Boolean).slice(0, 5);
+  const pattern = `%${terms.join("%")}%`;
+  const result = await query(
+    `select id, memory_key, memory_text, source, memory_type, importance, confidence, created_at, updated_at
+     from hermes_memories
+     where memory_text ilike $1
+        or memory_key ilike $1
+        or memory_type ilike $1
+     order by coalesce(last_used_at, updated_at, created_at) desc, id desc
+     limit $2`,
+    [pattern, Math.max(1, Math.min(Number(limit) || 5, 10))],
+  );
+
+  if (result.rows.length) {
+    await query(`update hermes_memories set last_used_at=now() where id = any($1::bigint[])`, [result.rows.map((r) => r.id)]);
+  }
+
+  return result.rows;
+}
+
+async function getOperatorMemoryStats() {
+  const byType = await query(
+    `select coalesce(memory_type, 'uncategorized') as memory_type, count(*)::int as count
+     from hermes_memories
+     group by coalesce(memory_type, 'uncategorized')
+     order by count desc, memory_type asc`,
+  );
+  const total = await query(
+    `select count(*)::int as total, max(coalesce(updated_at, created_at)) as latest_memory_at
+     from hermes_memories`,
+  );
+  return {
+    total: total.rows[0]?.total || 0,
+    latest_memory_at: total.rows[0]?.latest_memory_at || null,
+    by_type: byType.rows || [],
+  };
+}
+
 async function runHermesDispatcher(input) {
 
   const lowerInput = String(input || "").toLowerCase();
@@ -902,6 +973,9 @@ NEXT ACTION:
 
 
 module.exports = {
+  rememberOperatorMemory,
+  recallOperatorMemories,
+  getOperatorMemoryStats,
   recallStructuredMemories,
   ensureGBrainSchema,
   learnFromText,

--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ const {
   ensureGBrainSchema,
   learnFromText,
   recallMemories,
+  rememberOperatorMemory,
+  recallOperatorMemories,
+  getOperatorMemoryStats,
   runDispatcher,
   buildCodexPrompt,
   reviewCodexResult,
@@ -676,6 +679,168 @@ function buildUnknownTelegramReply(text) {
   ].join("\n");
 }
 
+
+function redactSensitiveText(value) {
+  return String(value || "")
+    .replace(/(token|apikey|api_key|authorization|password|bearer|secret)\s*[:=]?\s*[^\s,;]+/gi, "$1=[REDACTED]")
+    .replace(/postgres(?:ql)?:\/\/[^\s@]+@/gi, "postgres://[REDACTED]@");
+}
+
+function truncateForTelegram(value, max = 500) {
+  const text = redactSensitiveText(value).replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function formatAge(seconds) {
+  const total = Math.max(0, Number(seconds) || 0);
+  if (!total) return "-";
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  if (hours) return `${hours}h ${minutes}m`;
+  return `${minutes || 1}m`;
+}
+
+function parsePositiveIntegerArg(text, command) {
+  const raw = String(text || "").trim().split(/\s+/)[1];
+  const id = Number(raw);
+  if (!Number.isInteger(id) || id <= 0) {
+    return { error: `Dùng: ${command} <id_số_nguyên_dương>` };
+  }
+  return { id };
+}
+
+async function buildTelegramStatusMessage() {
+  const health = await getSystemHealth();
+  const latest = health.latest_task;
+  const latestLine = latest
+    ? `#${latest.id} ${latest.status} — ${truncateForTelegram(latest.input_text, 80)}`
+    : "-";
+  const workerAge = health.worker.last_heartbeat_at
+    ? formatAge(Math.floor((Date.now() - new Date(health.worker.last_heartbeat_at).getTime()) / 1000))
+    : "-";
+  const warnings = (health.warnings || []).slice(0, 2).map((w) => `- Warning: ${truncateForTelegram(w, 120)}`);
+
+  return [
+    "Hermes Status",
+    `- App: ${health.app?.ok ? "OK" : "WARN"}`,
+    `- DB: ${health.db?.ok ? "OK" : "DOWN"}`,
+    `- Worker: ${health.worker?.alive ? "OK" : "UNKNOWN"}${workerAge !== "-" ? ` (heartbeat ${workerAge} ago)` : ""}`,
+    `- Env: ${health.app_env || "development"} / ${health.env || "dev"}`,
+    `- Project: ${truncateForTelegram(health.projectRoot || "-", 120)}`,
+    `- Pending: ${health.queue.pending}`,
+    `- Planned: ${health.queue.planned}`,
+    `- Pending approval: ${health.queue.pending_approval}`,
+    `- Approved: ${health.queue.approved}`,
+    `- Running: ${health.queue.running}`,
+    `- Completed 24h: ${health.queue.completed_24h}`,
+    `- Failed 24h: ${health.queue.failed_24h}`,
+    `- Oldest pending: ${formatAge(health.queue.oldest_pending_seconds)}`,
+    `- Oldest approval: ${formatAge(health.queue.oldest_pending_approval_seconds)}`,
+    `- Latest task: ${latestLine}`,
+    ...warnings,
+  ].join("\n");
+}
+
+async function buildTelegramTaskMessage(text) {
+  const parsed = parsePositiveIntegerArg(text, "/task");
+  if (parsed.error) return parsed.error;
+  const id = parsed.id;
+  const tRes = await query(
+    `select id,status,intent,input_text,created_at,updated_at,approval_expires_at,approved_by,approved_at,result_text,error_text,result_summary
+     from hermes_tasks
+     where id=$1
+     limit 1`,
+    [id],
+  );
+  const t = tRes.rows[0];
+  if (!t) return `Không tìm thấy task #${id}.`;
+  const result = t.result_text || (t.result_summary ? JSON.stringify(t.result_summary) : "");
+  return [
+    `Task #${t.id}`,
+    `- Status: ${t.status}`,
+    `- Intent: ${t.intent || "-"}`,
+    `- Input: ${truncateForTelegram(t.input_text, 500)}`,
+    `- Created: ${t.created_at ? new Date(t.created_at).toISOString() : "-"}`,
+    `- Updated: ${t.updated_at ? new Date(t.updated_at).toISOString() : "-"}`,
+    `- Approval expires: ${t.approval_expires_at ? new Date(t.approval_expires_at).toISOString() : "-"}`,
+    `- Approved by: ${t.approved_by || "-"}`,
+    `- Approved at: ${t.approved_at ? new Date(t.approved_at).toISOString() : "-"}`,
+    result ? `- Result: ${truncateForTelegram(result, 700)}` : null,
+    t.error_text ? `- Error: ${truncateForTelegram(t.error_text, 700)}` : null,
+  ].filter(Boolean).join("\n");
+}
+
+async function buildTelegramEventsMessage(text) {
+  const parsed = parsePositiveIntegerArg(text, "/events");
+  if (parsed.error) return parsed.error;
+  const id = parsed.id;
+  const taskExists = await query(`select id from hermes_tasks where id=$1 limit 1`, [id]);
+  if (!taskExists.rows[0]) return `Không tìm thấy task #${id}.`;
+  let ev;
+  try {
+    ev = await query(
+      `select id,event_type,message,payload,metadata,created_at
+       from hermes_task_events
+       where task_id=$1
+       order by sequence_id desc nulls last, created_at desc, id desc
+       limit 12`,
+      [id],
+    );
+  } catch {
+    ev = await query(
+      `select id,event_type,message,payload,metadata,created_at
+       from hermes_task_events
+       where task_id=$1
+       order by created_at desc, id desc
+       limit 12`,
+      [id],
+    );
+  }
+  if (!ev.rows.length) return `Task #${id} chưa có event.`;
+  const rows = ev.rows.reverse().map((e) => {
+    const detail = e.message || JSON.stringify(e.metadata || e.payload || {});
+    return `- ${new Date(e.created_at).toISOString()} — ${e.event_type}: ${truncateForTelegram(detail, 180)}`;
+  });
+  return [`Events for task #${id}`, ...rows].join("\n");
+}
+
+async function buildRememberMessage(text) {
+  const memoryText = String(text || "").replace(/^\/remember\b/i, "").trim();
+  if (!memoryText) return "Dùng: /remember <thing Hermes should remember>";
+  const memory = await rememberOperatorMemory(memoryText, "telegram_operator");
+  return [
+    "Memory stored ✅",
+    `- ID: ${memory.id || "-"}`,
+    `- Type: ${memory.memory_type || "project_context"}`,
+    `- Summary: ${truncateForTelegram(memory.memory_text, 240)}`,
+    "- Retrieval: use /recall <keyword>",
+  ].join("\n");
+}
+
+async function buildRecallMessage(text) {
+  const keyword = String(text || "").replace(/^\/recall\b/i, "").trim();
+  if (!keyword) return "Dùng: /recall <keyword>";
+  const memories = await recallOperatorMemories(keyword, 5);
+  if (!memories.length) return "No matching memory found.";
+  return [
+    `Memory recall for: ${truncateForTelegram(keyword, 80)}`,
+    ...memories.map((m) => `- #${m.id} [${m.memory_type || "memory"}] ${truncateForTelegram(m.memory_text, 260)}`),
+  ].join("\n");
+}
+
+async function buildMemoryStatsMessage() {
+  const stats = await getOperatorMemoryStats();
+  const byType = stats.by_type.length
+    ? stats.by_type.map((r) => `- ${r.memory_type}: ${r.count}`).join("\n")
+    : "- none: 0";
+  return [
+    "Memory Stats",
+    `- Total: ${stats.total}`,
+    `- Latest: ${stats.latest_memory_at ? new Date(stats.latest_memory_at).toISOString() : "-"}`,
+    byType,
+  ].join("\n");
+}
+
 function isAllowed(userId) {
   return ALLOWED_USER_IDS.includes(Number(userId));
 }
@@ -1138,17 +1303,31 @@ if (callback) {
       const normalized = text.toLowerCase();
       console.log("INCOMING:", { userId, text });
 
-      await query(
-        `insert into telegram_users (telegram_user_id, is_allowed)
-         values ($1, $2)
-         on conflict (telegram_user_id)
-         do update set last_seen_at = now()`,
-        [userId, isAllowed(userId)]
-      );
-
       if (!isAllowed(userId)) {
         await sendTelegramMessage(chatId, "Bạn không có quyền sử dụng Hermes.");
         continue;
+      }
+
+      if (normalized === "/status") {
+        try {
+          await sendTelegramMessage(chatId, await buildTelegramStatusMessage());
+        } catch (err) {
+          await sendTelegramMessage(chatId, `Hermes Status\n- App: WARN\n- DB: DOWN or unavailable\n- Warning: ${truncateForTelegram(err.message, 200)}`);
+        }
+        console.log("COMMAND_HANDLED /status", { userId, chatId });
+        continue;
+      }
+
+      try {
+        await query(
+          `insert into telegram_users (telegram_user_id, is_allowed)
+           values ($1, $2)
+           on conflict (telegram_user_id)
+           do update set last_seen_at = now()`,
+          [userId, isAllowed(userId)]
+        );
+      } catch (err) {
+        console.warn("telegram user upsert failed:", err.message);
       }
 
       if (normalized === "/start") {
@@ -1168,32 +1347,56 @@ if (callback) {
         console.log("COMMAND_HANDLED /health", { userId, chatId });
         continue;
       }
-      if (normalized.startsWith("/task ")) {
-        const id = Number(text.split(/\s+/)[1]);
-        if (!Number.isInteger(id) || id <= 0) { await sendTelegramMessage(chatId, "Dùng: /task <id_số_nguyên_dương>"); continue; }
-        const tRes = await query(`select id,status,intent,input_text,created_at,updated_at,approved_by,approved_at,result_text,error_text,result_summary from hermes_tasks where id=$1 limit 1`, [id]);
-        const t = tRes.rows[0];
-        if (!t) { await sendTelegramMessage(chatId, `Không tìm thấy task #${id}.`); continue; }
-        const eRes = await query(`select event_type,message,created_at from hermes_task_events where task_id=$1 order by id desc limit 10`, [id]);
-        const events = eRes.rows.reverse().map((e,i)=>`${i+1}. ${e.event_type} — ${String(e.message||'').slice(0,120)}`).join("\n");
-        await sendTelegramMessage(chatId, `📌 Task #${t.id}\n\nStatus: ${t.status}\nIntent: ${t.intent || '-'}\nInput: ${String(t.input_text||'').slice(0,300)}\nApproval: ${t.approved_by ? `approved by ${t.approved_by}` : 'n/a'}\n\nLatest events:\n${events || '-' }\n\nResult: ${String(t.result_text || t.error_text || '-').replace(/(token|apikey|authorization|password|bearer)\s*[:=]?\s*[^\s]+/gi, "$1=[REDACTED]").slice(0,500)}`);
-        continue;
-      }
-      if (normalized.startsWith("/events ")) {
-        const parts = text.split(/\s+/);
-        const id = Number(parts[1]); if (!Number.isInteger(id) || id <= 0) { await sendTelegramMessage(chatId, "Dùng: /events <id> [limit 1-50] [offset>=0]"); continue; }
-        const limit = Math.min(50, Math.max(1, Number(parts[2] || 20)));
-        const offsetArg = Math.max(0, Number(parts[3] || 0));
-        let ev;
+      if (normalized === "/task" || normalized.startsWith("/task ")) {
         try {
-          ev = await query(`select id,event_type,message,created_at from hermes_task_events where task_id=$1 order by sequence_id asc nulls last, id asc, created_at asc limit $2 offset $3`, [id, limit, offsetArg]);
-        } catch {
-          ev = await query(`select id,event_type,message,created_at from hermes_task_events where task_id=$1 order by id asc, created_at asc limit $2 offset $3`, [id, limit, offsetArg]);
+          await sendTelegramMessage(chatId, await buildTelegramTaskMessage(text));
+        } catch (err) {
+          await sendTelegramMessage(chatId, `Lỗi /task: ${truncateForTelegram(err.message, 200)}`);
         }
-        const msg = ev.rows.map((e,i)=>`${i+1+offsetArg}. ${new Date(e.created_at).toISOString()} — ${e.event_type}\n   ${String(e.message||'').slice(0,120)}`).join("\n\n") || "Không có event.";
-        await sendTelegramMessage(chatId, `🧾 Events for task #${id}\n\n${msg}`);
+        console.log("COMMAND_HANDLED /task", { userId, chatId });
         continue;
       }
+
+      if (normalized === "/events" || normalized.startsWith("/events ")) {
+        try {
+          await sendTelegramMessage(chatId, await buildTelegramEventsMessage(text));
+        } catch (err) {
+          await sendTelegramMessage(chatId, `Lỗi /events: ${truncateForTelegram(err.message, 200)}`);
+        }
+        console.log("COMMAND_HANDLED /events", { userId, chatId });
+        continue;
+      }
+
+      if (normalized === "/memory stats") {
+        try {
+          await sendTelegramMessage(chatId, await buildMemoryStatsMessage());
+        } catch (err) {
+          await sendTelegramMessage(chatId, `Lỗi /memory stats: ${truncateForTelegram(err.message, 200)}`);
+        }
+        console.log("COMMAND_HANDLED /memory stats", { userId, chatId });
+        continue;
+      }
+
+      if (normalized === "/remember" || normalized.startsWith("/remember ")) {
+        try {
+          await sendTelegramMessage(chatId, await buildRememberMessage(text));
+        } catch (err) {
+          await sendTelegramMessage(chatId, `Lỗi /remember: ${truncateForTelegram(err.message, 200)}`);
+        }
+        console.log("COMMAND_HANDLED /remember", { userId, chatId });
+        continue;
+      }
+
+      if (normalized === "/recall" || normalized.startsWith("/recall ")) {
+        try {
+          await sendTelegramMessage(chatId, await buildRecallMessage(text));
+        } catch (err) {
+          await sendTelegramMessage(chatId, `Lỗi /recall: ${truncateForTelegram(err.message, 200)}`);
+        }
+        console.log("COMMAND_HANDLED /recall", { userId, chatId });
+        continue;
+      }
+
       if (normalized.startsWith("/approve")) {
         const id = Number(text.split(/\s+/)[1]);
         if (!Number.isInteger(id) || id <= 0) { await sendTelegramMessage(chatId, "Dùng: /approve <id_số_nguyên_dương>"); continue; }
@@ -1228,11 +1431,14 @@ Audit lỗi/sự cố và tạo hướng xử lý.
 /deploy-check <nội dung deploy>
 Checklist an toàn trước deploy.
 
-/learn <bài học>
-Lưu memory vào GBrain.
+/remember <thing Hermes should remember>
+Lưu memory an toàn, không tạo execution task.
 
-/recall <từ khóa>
-Tìm lại memory trong GBrain.
+/recall <keyword>
+Tìm lại memory an toàn.
+
+/memory stats
+Xem số lượng memory.
 
 Flow chuẩn:
 1. /codex <vấn đề>


### PR DESCRIPTION
### Motivation
- Fix a runtime error where `crypto.createHash is not a function` by ensuring Node's crypto is used explicitly. 
- Provide operators concise, safe inspection and memory controls via Telegram so debugging and ops workflows do not create execution tasks. 
- Keep approval snapshot hashing stable and preserve existing safety/approval semantics while extending read-only operator functionality. 

### Description
- Replace ambiguous `crypto` usages with an explicit Node import (e.g. `const nodeCrypto = require('node:crypto')`) and update callsites in `approvalSnapshot.js`, `dispatcher/idempotency.js`, and `dispatcher/approval.ts` so `createHash`/`randomBytes` run on Node crypto. 
- Harden health collection in `dispatcher/health.js` by adding `safeQuery` which returns partial health data and `warnings`, and include queue counts, oldest pending/approval ages, latest task, worker heartbeat, environment and project root (read-only queries only). 
- Add Telegram operator commands and helpers in `index.js`: `/status` (compact health summary), `/task <id>` (read-only task inspect), `/events <id>` (task event timeline), and memory commands `/remember <text>`, `/recall <keyword>`, `/memory stats` with truncation/redaction and input validation so none of these create execution tasks or enter the default task path. 
- Extend `gbrain.js` with safe operator memory functions `rememberOperatorMemory`, `recallOperatorMemories`, and `getOperatorMemoryStats` backed by `hermes_memories` and wired into the Telegram flows. 
- Files changed: `approvalSnapshot.js`, `dispatcher/approval.ts`, `dispatcher/health.js`, `dispatcher/idempotency.js`, `gbrain.js`, `index.js`.
- DB schema: no schema files were modified; all memory reads/writes reuse existing `hermes_memories` and other tables without destructive migration. 
- Routing preservation: casual small-talk handling remains before default task creation and still does not create `hermes_tasks`, and task-like inputs such as `git status` continue to follow the existing `createTask` / approval flow.

### Testing
- Ran static checks: `node --check index.js`, `node --check gbrain.js`, `node --check dispatcher/health.js`, `node --check approvalSnapshot.js`, and `node --check dispatcher/idempotency.js`, all of which succeeded. 
- Performed a deterministic approval snapshot smoke check by calling `canonicalizeApprovalSnapshot` + `hashApprovalSnapshot` twice and asserting stable SHA-256 output, which passed and printed a 64-char hex hash. 
- Ran `git diff --check` and confirmed no whitespace or trailing-diff errors, and verified `package.json` has no `test`/`lint` scripts so `npm test`/`npm run lint` were not run. 
- Manual end-to-end Telegram and DB checks were not executed in this environment (no live Telegram or DB access); these remain required in staging: verify that `/status`, `/task <id>`, `/events <id>`, `/remember`, `/recall`, and `/memory stats` reply correctly and create no `hermes_tasks` rows, confirm small-talk (`Hi`) does not create tasks, and confirm `git status` still creates/completes a real task. 

Notes / Known risks: the new `/status` reads worker heartbeat from `hermes_worker_status` and will surface warnings if DB or worker tables are unavailable; memory recall uses simple `ILIKE` pattern matching (no semantic search) which is safe but may return coarse results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff5c94531c8333b52db19b47315470)