### PR TITLE
Add external CLI capability routing

### DIFF
--- a/dispatcher/externalCliTools.js
+++ b/dispatcher/externalCliTools.js
@@ -1,0 +1,235 @@
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+
+const execFileAsync = promisify(execFile);
+
+const TOOL_NAMES = [
+  'company-goat',
+  'contact-goat',
+  'flight-goat',
+  'archive-is',
+  'apartments',
+  'hackernews',
+  'espn',
+  'printing-press',
+];
+
+const TOOL_DEFINITIONS = {
+  'company-goat': {
+    label: 'startup/company diligence',
+    keywords: ['company-goat', 'startup', 'company diligence', 'company', 'diligence', 'investor', 'market research'],
+    safeSmokeCommand: 'command -v company-goat && company-goat --help | head -40',
+  },
+  'contact-goat': {
+    label: 'contact discovery/enrichment',
+    keywords: ['contact-goat', 'contact', 'email', 'lead'],
+    safeSmokeCommand: 'command -v contact-goat && contact-goat --help | head -40',
+  },
+  'flight-goat': {
+    label: 'flight search',
+    keywords: ['flight-goat', 'flight', 'airfare', 'airport'],
+    safeSmokeCommand: 'command -v flight-goat && flight-goat --help | head -40',
+  },
+  'archive-is': {
+    label: 'clean markdown extraction',
+    keywords: ['archive-is', 'archive', 'clean markdown', 'markdown extraction', 'extract markdown', 'article extraction'],
+    safeSmokeCommand: 'command -v archive-is && archive-is --help | head -40',
+  },
+  apartments: {
+    label: 'apartment search',
+    keywords: ['apartments', 'apartment', 'rent', 'rental', 'housing'],
+    safeSmokeCommand: 'command -v apartments && apartments --help | head -40',
+  },
+  hackernews: {
+    label: 'Hacker News search/summarization',
+    keywords: ['hackernews', 'hacker news', 'hn'],
+    safeSmokeCommand: 'command -v hackernews && hackernews --help | head -40',
+  },
+  espn: {
+    label: 'sports information',
+    keywords: ['espn', 'sports', 'score', 'game', 'standings'],
+    safeSmokeCommand: 'command -v espn && espn --help | head -40',
+  },
+  'printing-press': {
+    label: 'publishing/formatting',
+    keywords: ['printing-press', 'printing press', 'publish', 'press', 'format'],
+    safeSmokeCommand: 'command -v printing-press && printing-press --help | head -40',
+  },
+};
+
+function redact(text = '') {
+  return String(text || '')
+    .replace(/(token|apikey|api_key|authorization|password|bearer|secret)\s*[:=]?\s*[^\s]+/gi, '$1=[REDACTED]')
+    .slice(0, 6000);
+}
+
+function mentionsNoRun(text = '') {
+  const t = String(text || '').toLowerCase();
+  return /do not run commands|không chạy lệnh|don't run commands|no commands/.test(t);
+}
+
+function routeTool(text = '') {
+  const lower = String(text || '').toLowerCase();
+  for (const name of TOOL_NAMES) {
+    if ((TOOL_DEFINITIONS[name].keywords || []).some((keyword) => lower.includes(keyword))) {
+      return { name, ...TOOL_DEFINITIONS[name] };
+    }
+  }
+  return null;
+}
+
+function isExternalCliTask(text = '') {
+  const lower = String(text || '').toLowerCase();
+  return lower.includes('capability routing inventory')
+    || lower.includes('remembered capability')
+    || TOOL_NAMES.some((name) => lower.includes(name))
+    || Boolean(routeTool(text));
+}
+
+function buildPlan(tool, commands) {
+  return [
+    { step: 'route_capability', tool: tool?.name || null },
+    { step: 'validate_safe_allowlist', commands },
+    { step: 'execute_safe_smoke_commands', commands },
+    { step: 'log_action_results' },
+    { step: 'reply_summary' },
+  ];
+}
+
+function parseSafeRequestedCommands(text = '', routedToolName = null) {
+  const lower = String(text || '').toLowerCase();
+  const commands = [];
+  for (const name of TOOL_NAMES) {
+    if (routedToolName && name !== routedToolName) continue;
+    if (lower.includes(`command -v ${name}`)) commands.push(`command -v ${name}`);
+    if (lower.includes(`${name} --help | head -40`)) commands.push(`${name} --help | head -40`);
+    if (lower.includes(`${name} --agent`)) commands.push(`${name} --agent`);
+  }
+  return [...new Set(commands)];
+}
+
+function parseAllowedSmokeCommand(command = '') {
+  const trimmed = String(command || '').trim();
+  let match = trimmed.match(/^command -v ([a-z0-9][a-z0-9-]*)$/);
+  if (match && TOOL_NAMES.includes(match[1])) {
+    return { type: 'command-v', tool: match[1] };
+  }
+
+  match = trimmed.match(/^([a-z0-9][a-z0-9-]*) --help(?: \| head -(\d{1,2}))?$/);
+  if (match && TOOL_NAMES.includes(match[1])) {
+    const lines = match[2] ? Number(match[2]) : 80;
+    if (lines >= 1 && lines <= 80) return { type: 'help', tool: match[1], lines };
+  }
+
+  match = trimmed.match(/^([a-z0-9][a-z0-9-]*) --agent(?: \| head -(\d{1,2}))?$/);
+  if (match && TOOL_NAMES.includes(match[1])) {
+    const lines = match[2] ? Number(match[2]) : 80;
+    if (lines >= 1 && lines <= 80) return { type: 'agent', tool: match[1], lines };
+  }
+
+  return null;
+}
+
+async function runAllowedSmokeCommand(command, options = {}) {
+  const parsed = parseAllowedSmokeCommand(command);
+  if (!parsed) {
+    return { command, status: 'blocked', output: '', error: 'not_in_external_cli_allowlist' };
+  }
+
+  try {
+    if (parsed.type === 'command-v') {
+      const result = await execFileAsync('/bin/bash', ['-lc', `command -v ${parsed.tool}`], {
+        timeout: options.timeout || 10000,
+        maxBuffer: 128 * 1024,
+        env: process.env,
+      });
+      return { command, status: 'completed', output: redact(result.stdout || result.stderr || '') };
+    }
+
+    const arg = parsed.type === 'help' ? '--help' : '--agent';
+    const result = await execFileAsync(parsed.tool, [arg], {
+      shell: false,
+      timeout: options.timeout || 15000,
+      maxBuffer: 256 * 1024,
+      env: process.env,
+    });
+    const output = redact(result.stdout || result.stderr || '').split('\n').slice(0, parsed.lines).join('\n');
+    return { command, status: 'completed', output };
+  } catch (err) {
+    const output = redact(`${err.stdout || ''}${err.stderr || ''}`.trim());
+    return { command, status: 'failed', output, error: redact(err.message || 'command_failed') };
+  }
+}
+
+async function logAction(query, taskId, actionName, input, output, status) {
+  await query(
+    `insert into hermes_action_logs (task_id, action_name, input, output, status)
+     values ($1, $2, $3::jsonb, $4::jsonb, $5)`,
+    [taskId, actionName, JSON.stringify(input || {}), JSON.stringify(output || {}), status],
+  );
+}
+
+async function handleExternalCliTask(task, deps) {
+  const text = task.input_text || '';
+  if (!isExternalCliTask(text)) return null;
+
+  const tool = routeTool(text);
+  let commands = mentionsNoRun(text) ? [] : parseSafeRequestedCommands(text, tool?.name || null);
+  if (!mentionsNoRun(text) && tool && commands.length === 0) {
+    commands = [`command -v ${tool.name}`, `${tool.name} --help | head -40`];
+  }
+  const plan = buildPlan(tool, commands);
+
+  if (!tool) {
+    const summary = {
+      status: 'blocked',
+      output: 'No remembered capability tool matched this Telegram task.',
+      tool: null,
+      commands,
+      plan,
+    };
+    await logAction(deps.query, task.id, 'external_cli_route', { text }, summary, 'blocked');
+    return summary;
+  }
+
+  if (commands.length === 0) {
+    const summary = {
+      status: 'completed',
+      output: `Recommended tool: ${tool.name} (${tool.label}). No commands were run.`,
+      tool: tool.name,
+      commands: [],
+      plan,
+    };
+    await logAction(deps.query, task.id, 'external_cli_route', { text }, summary, 'completed');
+    return summary;
+  }
+
+  const results = [];
+  for (const command of commands) {
+    const result = await runAllowedSmokeCommand(command);
+    results.push(result);
+    await logAction(deps.query, task.id, 'external_cli_command', { tool: tool.name, command }, result, result.status);
+  }
+
+  const summary = {
+    status: results.every((r) => r.status === 'completed') ? 'completed' : 'failed',
+    output: results.map((r) => `$ ${r.command}\n${r.output || r.error || r.status}`).join('\n\n'),
+    tool: tool.name,
+    commands,
+    plan,
+    results,
+  };
+  await logAction(deps.query, task.id, 'external_cli_route', { text, tool: tool.name, commands }, summary, summary.status);
+  return summary;
+}
+
+module.exports = {
+  TOOL_NAMES,
+  TOOL_DEFINITIONS,
+  routeTool,
+  isExternalCliTask,
+  parseAllowedSmokeCommand,
+  parseSafeRequestedCommands,
+  runAllowedSmokeCommand,
+  handleExternalCliTask,
+};

--- a/dispatcher/safety.js
+++ b/dispatcher/safety.js
@@ -1,3 +1,11 @@
+
+const EXTERNAL_CLI_TOOLS = '(company-goat|contact-goat|flight-goat|archive-is|apartments|hackernews|espn|printing-press)';
+const EXTERNAL_CLI_SAFE_PATTERNS = [
+  new RegExp(`^command -v ${EXTERNAL_CLI_TOOLS}$`),
+  new RegExp(`^${EXTERNAL_CLI_TOOLS} --help( \\| head -([1-7]?[0-9]|80))?$`),
+  new RegExp(`^${EXTERNAL_CLI_TOOLS} --agent( \\| head -([1-7]?[0-9]|80))?$`),
+];
+
 const SAFE_PATTERNS = [
   /^ls(\s|$)/,
   /^cat(\s|$)/,
@@ -27,6 +35,7 @@ function classifyCommand(command) {
   if (DANGEROUS_PATTERNS.some((p) => p.test(cmd))) return { allowed: true, riskLevel: 'dangerous' };
   if (RISKY_PATTERNS.some((p) => p.test(cmd))) return { allowed: true, riskLevel: 'risky' };
   if (SAFE_PATTERNS.some((p) => p.test(cmd))) return { allowed: true, riskLevel: 'safe' };
+  if (EXTERNAL_CLI_SAFE_PATTERNS.some((p) => p.test(cmd))) return { allowed: true, riskLevel: 'safe' };
   return { allowed: false, riskLevel: 'unknown', reason: 'unknown command' };
 }
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const {
   buildAudit,
   buildDeployCheck,
 } = require("./gbrain");
+const { isExternalCliTask, routeTool } = require('./dispatcher/externalCliTools');
 const app = express();
 app.use(express.json());
 
@@ -653,7 +654,7 @@ function isCasualTelegramInput(text) {
 
 function isTaskLikeTelegramInput(text) {
   const normalizedIntentText = normalizeTelegramIntentText(text);
-  return TASK_LIKE_TELEGRAM_PATTERNS.some((pattern) => pattern.test(normalizedIntentText));
+  return isExternalCliTask(normalizedIntentText) || TASK_LIKE_TELEGRAM_PATTERNS.some((pattern) => pattern.test(normalizedIntentText));
 }
 
 function buildCasualTelegramReply() {
@@ -2320,6 +2321,14 @@ NEXT ACTION:
       if (!isTaskLikeTelegramInput(text)) {
         console.log("UNKNOWN_INTENT_CLARIFICATION", { userId, chatId, text });
         await sendTelegramMessage(chatId, buildUnknownTelegramReply(text));
+        continue;
+      }
+
+      if (isExternalCliTask(text) && /do not run commands|don't run commands|no commands|không chạy lệnh/i.test(text)) {
+        const tool = routeTool(text);
+        await sendTelegramMessage(chatId, tool
+          ? `Recommended tool: ${tool.name} (${tool.label}). No commands were run.`
+          : 'No remembered capability tool matched this request. No commands were run.');
         continue;
       }
 

--- a/worker.js
+++ b/worker.js
@@ -16,6 +16,7 @@ const { handleTaskFailure } = require('./dispatcher/autodebug');
 const { createPlanForTask, taskType } = require('./dispatcher/planner');
 const { executePlan } = require('./dispatcher/executor');
 const { runDueGoals } = require('./dispatcher/goalRunner');
+const { handleExternalCliTask } = require('./dispatcher/externalCliTools');
 
 const rawExecAsync = promisify(exec);
 const { canonicalizeApprovalSnapshot, hashApprovalSnapshot } = require('./approvalSnapshot');
@@ -1203,6 +1204,42 @@ async function processOneTask() {
     const session = await getOrCreateSession(task.id);
     await event(task.id, "execution_started", "Worker started task");
     await query(`update hermes_tasks set execution_started_at=now(), updated_at=now() where id=$1`, [task.id]);
+
+    const externalCliResult = await handleExternalCliTask(task, { query, event });
+    if (externalCliResult) {
+      const finalResult = {
+        status: externalCliResult.status === 'completed' ? 'completed' : 'failed',
+        review_status: externalCliResult.status === 'completed' ? 'approved' : 'rejected',
+        issues: externalCliResult.status === 'completed' ? [] : [externalCliResult.output || 'external_cli_failed'],
+        output: externalCliResult.output,
+      };
+      await updateSession(task.id, { status: finalResult.status, last_gate_status: finalResult.review_status === 'approved' ? 'passed' : 'failed' });
+      await logSessionAction(session.id, 'external_cli', finalResult.review_status, finalResult);
+      if (finalResult.status === 'completed') {
+        await releaseTask(task.id, WORKER_ID, 'completed', JSON.stringify(finalResult));
+      } else {
+        await failTask(task.id, WORKER_ID, finalResult.issues.join('; '), false);
+      }
+      await query(`update hermes_tasks set execution_completed_at=now(), duration_ms=extract(epoch from (now()-coalesce(execution_started_at,now())))*1000, result_summary=$2::jsonb where id=$1`, [task.id, JSON.stringify({
+        task_id: task.id,
+        final_status: finalResult.status,
+        intent: 'external_cli',
+        approval_status: 'approved',
+        actions_attempted: externalCliResult.commands?.length || 0,
+        actions_succeeded: (externalCliResult.results || []).filter((r) => r.status === 'completed').length,
+        actions_failed: (externalCliResult.results || []).filter((r) => r.status !== 'completed').length,
+        actions: externalCliResult.commands || [],
+        key_output: externalCliResult.output,
+        safe_error: finalResult.status === 'completed' ? null : finalResult.issues.join('; '),
+        next_operator_action: 'Use /task to inspect logs, or approve a safe smoke command if needed.',
+        confidence_level: 'medium',
+      })]);
+      await event(task.id, "execution_completed", "External CLI routing completed", { tool: externalCliResult.tool, commands: externalCliResult.commands || [] });
+      clearInterval(heartbeatTimer);
+      await sendTelegramMessage(task.telegram_chat_id, `Task #${task.id} external CLI result:
+${String(externalCliResult.output || '').slice(0, 3000)}`, null, task.telegram_user_id);
+      return;
+    }
 
     await event(task.id, "plan_started", "Planning started");
     const plan = await createPlanForTask(task);


### PR DESCRIPTION
### Motivation
- Enable Hermes to detect and route remembered external CLI tools from Telegram tasks while preserving existing approval and safety semantics. 
- Provide deterministic routing heuristics and a minimal, auditable smoke-check execution surface (presence/help/agent) for tools in the memory inventory. 
- Keep operator-facing flows safe by not exposing secrets, not broadening shell execution, and not weakening approval snapshot checks or worker execution-time validation.

### Description
- Added `dispatcher/externalCliTools.js` which contains a remembered tool inventory, routing heuristics (`routeTool` / `isExternalCliTask`), deterministic plan construction (`buildPlan`), safe smoke-command parsing (`parseAllowedSmokeCommand` / `parseSafeRequestedCommands`), redacted execution (`runAllowedSmokeCommand`), and `handleExternalCliTask` which logs into `hermes_action_logs`.
- Extended the centralized safety checker in `dispatcher/safety.js` to treat only the external-CLI smoke commands as safe (patterns for `command -v <tool>`, `<tool> --help | head -N`, and `<tool> --agent`) so CLI smoke checks are allowed but arbitrary shell usage is not.
- Updated Telegram routing in `index.js` so remembered external-CLI requests are considered task-like and a “do not run commands” phrasing returns a capability selection reply instead of creating a task that executes commands.
- Integrated the external-CLI handler into the worker (`worker.js`) after the existing approval snapshot validation and before the generic planner, so external-CLI routing executes only through the dedicated allowlisted handler, logs results to `hermes_action_logs`, and finishes the task lifecycle (complete/fail) without bypassing approvals.

### Testing
- Static JS checks: ran `node --check index.js`, `node --check worker.js`, `node --check dispatcher/externalCliTools.js`, and `node --check dispatcher/safety.js` and they passed.
- Behavioral smoke tests via Node snippets exercised routing and parsing: invoking `routeTool` returned `company-goat` for the startup/company diligence prompt, `parseSafeRequestedCommands` and `parseAllowedSmokeCommand` correctly parsed `command -v` and `--help | head -N` variants, and `classifyCommand` marks these smoke commands as safe.
- Executed `runAllowedSmokeCommand('command -v company-goat')` to verify safe-execution path and redaction behavior; the command path completed but returned a failed status on this host because the tool is not installed (expected; no installation assumed).
- Environment-dependent checks were attempted but could not run here: `docker` is not available in the sandbox so live `hermes_worker` container inspection could not be performed, and `psql`/`DATABASE_URL` were unavailable so historical `hermes_action_logs` queries against a live DB could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0000fb5a8c8333b0a43dee1e2c236b)