### PR TITLE
Add Hermes external CLI runtime image and installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM node:20-bullseye
+
+ARG GO_VERSION=1.26.3
+ARG TARGETARCH
+
+ENV GOPATH=/root/go \
+    GOBIN=/root/go/bin \
+    PATH=/root/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      bash \
+      ca-certificates \
+      curl \
+      git; \
+    rm -rf /var/lib/apt/lists/*; \
+    arch="${TARGETARCH:-amd64}"; \
+    case "$arch" in \
+      amd64) go_arch="amd64" ;; \
+      arm64) go_arch="arm64" ;; \
+      *) echo "unsupported TARGETARCH=$arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${go_arch}.tar.gz" -o /tmp/go.tgz; \
+    rm -rf /usr/local/go; \
+    tar -C /usr/local -xzf /tmp/go.tgz; \
+    rm -f /tmp/go.tgz; \
+    mkdir -p "$GOBIN"; \
+    go version
+
+WORKDIR /app
+
+COPY docker/hermes-entrypoint.sh /usr/local/bin/hermes-entrypoint
+COPY scripts/install-printing-press-clis.sh /usr/local/bin/install-printing-press-clis
+RUN chmod +x /usr/local/bin/hermes-entrypoint /usr/local/bin/install-printing-press-clis
+
+ENTRYPOINT ["hermes-entrypoint"]

--- a/README.md
+++ b/README.md
@@ -24,3 +24,28 @@ The environment guard layer uses consistent prefixes:
 - `[telegram]`
 - `[command]`
 - `[db guard]`
+
+## External CLI runtime layer
+
+The `app` and `worker` Compose services build the local Hermes image from `Dockerfile` instead of running the plain `node:20-bullseye` image. The image keeps Node 20 and adds only the runtime tools needed by Printing Press CLIs: `git`, `curl`, `ca-certificates`, `bash`, and a Go toolchain. The image sets `GOPATH=/root/go`, `GOBIN=/root/go/bin`, and prepends `/root/go/bin` to `PATH` so Go-installed binaries are executable by `hermes_worker`.
+
+At container start, `hermes-entrypoint` runs `install-printing-press-clis` unless `HERMES_INSTALL_PRINTING_PRESS_CLIS=false`. The installer uses runtime `GITHUB_TOKEN` or `GH_TOKEN` from the container environment; tokens are not copied into Docker image layers and installer error output is redacted before logging.
+
+Installed by default:
+
+- `printing-press`
+- `company-goat`
+- `contact-goat`
+- `flight-goat`
+- `archive-is`
+- `apartments`
+- `hackernews`
+- `espn`
+
+Manual safe install/retry inside a running container:
+
+```sh
+docker exec hermes_worker bash -lc 'install-printing-press-clis'
+```
+
+If private catalog or Go module access is missing, the script exits non-zero with a redacted diagnostic and asks for runtime `GITHUB_TOKEN`/`GH_TOKEN` access. It does not run enrichment commands; verification should use `command -v` and `--help` only.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   app:
-    image: node:20-bullseye
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: hermes_app
     working_dir: /app
     volumes:
@@ -9,6 +11,10 @@ services:
     env_file:
       - .env
     environment:
+      - APP_ENV=production
+      - HERMES_ENV=prod
+      - DATABASE_URL=postgres://hermes:hermes_password@hermes_db:5432/hermes
+      - HERMES_INSTALL_PRINTING_PRESS_CLIS=true
       - GIT_AUTHOR_NAME=Mason
       - GIT_AUTHOR_EMAIL=nguyenminhquanlcdn@gmail.com
       - GIT_COMMITTER_NAME=Mason
@@ -27,7 +33,9 @@ services:
     restart: unless-stopped
 
   worker:
-    image: node:20-bullseye
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: hermes_worker
     working_dir: /app
     volumes:
@@ -36,6 +44,10 @@ services:
     env_file:
       - .env
     environment:
+      - APP_ENV=production
+      - HERMES_ENV=prod
+      - DATABASE_URL=postgres://hermes:hermes_password@hermes_db:5432/hermes
+      - HERMES_INSTALL_PRINTING_PRESS_CLIS=true
       - GIT_AUTHOR_NAME=Mason
       - GIT_AUTHOR_EMAIL=nguyenminhquanlcdn@gmail.com
       - GIT_COMMITTER_NAME=Mason

--- a/docker/hermes-entrypoint.sh
+++ b/docker/hermes-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+export GOPATH="${GOPATH:-/root/go}"
+export GOBIN="${GOBIN:-${GOPATH}/bin}"
+export PATH="${GOBIN}:/usr/local/go/bin:${PATH}"
+
+if [ "${HERMES_INSTALL_PRINTING_PRESS_CLIS:-true}" != "false" ]; then
+  set +e
+  install-printing-press-clis
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    echo "[hermes-entrypoint] Printing Press CLI install did not complete (exit ${status}); starting Hermes anyway." >&2
+  fi
+fi
+
+exec "$@"

--- a/scripts/install-printing-press-clis.sh
+++ b/scripts/install-printing-press-clis.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+export GOPATH="${GOPATH:-/root/go}"
+export GOBIN="${GOBIN:-${GOPATH}/bin}"
+export PATH="${GOBIN}:/usr/local/go/bin:${PATH}"
+
+PRINTING_PRESS_GO_MODULE="${PRINTING_PRESS_GO_MODULE:-github.com/mvanhorn/cli-printing-press/v4/cmd/printing-press@latest}"
+PRINTING_PRESS_NPM_PACKAGE="${PRINTING_PRESS_NPM_PACKAGE:-@mvanhorn/printing-press}"
+PRINTING_PRESS_CLI_TOOLS="${PRINTING_PRESS_CLI_TOOLS:-company-goat contact-goat flight-goat archive-is apartments hackernews espn}"
+export GOPRIVATE="${GOPRIVATE:-github.com/mvanhorn/*}"
+
+log() {
+  printf '[printing-press-install] %s\n' "$*" >&2
+}
+
+have_any_token() {
+  [ -n "${GITHUB_TOKEN:-}" ] || [ -n "${GH_TOKEN:-}" ]
+}
+
+token_value() {
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    printf '%s' "$GITHUB_TOKEN"
+  else
+    printf '%s' "${GH_TOKEN:-}"
+  fi
+}
+
+setup_git_auth() {
+  local token askpass
+  token="$(token_value)"
+  [ -n "$token" ] || return 0
+  askpass="$(mktemp)"
+  chmod 700 "$askpass"
+  cat >"$askpass" <<'ASKPASS'
+#!/usr/bin/env bash
+case "$1" in
+  *Username*) printf '%s\n' 'x-access-token' ;;
+  *Password*) printf '%s\n' "${GITHUB_TOKEN:-${GH_TOKEN:-}}" ;;
+  *) printf '%s\n' "${GITHUB_TOKEN:-${GH_TOKEN:-}}" ;;
+esac
+ASKPASS
+  export GIT_ASKPASS="$askpass"
+  export GIT_TERMINAL_PROMPT=0
+  trap 'rm -f "${GIT_ASKPASS:-}"' EXIT
+}
+
+redact_file() {
+  local file="$1"
+  sed -E \
+    -e 's/(token|apikey|api_key|authorization|password|bearer|secret)([=: ]+)[^[:space:]]+/\1\2[REDACTED]/Ig' \
+    -e 's#https://[^:@[:space:]]+:[^@[:space:]]+@github.com#https://[REDACTED]@github.com#Ig' \
+    "$file" >&2 || true
+}
+
+run_redacted() {
+  local tmp status
+  tmp="$(mktemp)"
+  set +e
+  "$@" >"$tmp" 2>&1
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    log "command failed: $1 (exit $status)"
+    redact_file "$tmp"
+  fi
+  rm -f "$tmp"
+  return "$status"
+}
+
+mkdir -p "$GOBIN"
+setup_git_auth
+
+if ! command -v go >/dev/null 2>&1; then
+  log "Go toolchain is missing; cannot install Printing Press CLIs."
+  exit 10
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  log "npm is missing; cannot run the Printing Press installer."
+  exit 11
+fi
+
+if ! command -v printing-press >/dev/null 2>&1; then
+  log "installing printing-press Go binary"
+  if ! run_redacted go install "$PRINTING_PRESS_GO_MODULE"; then
+    log "printing-press binary install failed; check network and Go module access."
+    exit 20
+  fi
+else
+  log "printing-press already installed at $(command -v printing-press)"
+fi
+
+missing=""
+for tool in $PRINTING_PRESS_CLI_TOOLS; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    missing="$missing $tool"
+  fi
+done
+
+if [ -z "${missing# }" ]; then
+  log "requested Printing Press CLIs already installed"
+  exit 0
+fi
+
+if ! have_any_token; then
+  log "GITHUB_TOKEN/GH_TOKEN is not set; skipping private catalog CLI install for:${missing}"
+  log "Set GITHUB_TOKEN or GH_TOKEN at container runtime and rerun: install-printing-press-clis"
+  exit 30
+fi
+
+log "installing Printing Press CLIs:${missing}"
+if ! run_redacted npx -y "$PRINTING_PRESS_NPM_PACKAGE" install --cli-only $missing; then
+  log "Printing Press CLI install failed. Verify GITHUB_TOKEN/GH_TOKEN has catalog access and private Go module access."
+  exit 31
+fi
+
+still_missing=""
+for tool in $PRINTING_PRESS_CLI_TOOLS; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    still_missing="$still_missing $tool"
+  fi
+done
+
+if [ -n "${still_missing# }" ]; then
+  log "installer completed but these binaries are still missing:${still_missing}"
+  exit 32
+fi
+
+log "all requested Printing Press CLIs are installed"


### PR DESCRIPTION
### Motivation
- Provide a reproducible runtime layer so remembered external Printing Press CLIs are available inside `hermes_worker` rather than relying on the base `node:20-bullseye` image. 
- Keep installation secure and runtime-configurable by not baking private tokens into image layers and by detecting/reporting missing private access cleanly. 
- Preserve existing service/container names, project volumes, and `DATABASE_URL` host so startup and DB data remain unchanged. 

### Description
- Add `Dockerfile` that extends `node:20-bullseye`, installs only `git`, `curl`, `ca-certificates`, and `bash`, and downloads a Go toolchain while setting `GOPATH=/root/go`, `GOBIN=/root/go/bin`, and adding `/root/go/bin` to `PATH`. 
- Add `docker/hermes-entrypoint.sh` that sets Go env and runs the installer by default (opt-out via `HERMES_INSTALL_PRINTING_PRESS_CLIS=false`) while continuing startup if install fails. 
- Add `scripts/install-printing-press-clis.sh` installer that attempts to install `printing-press` (Go) and Printing Press CLIs (`company-goat`, `contact-goat`, `flight-goat`, `archive-is`, `apartments`, `hackernews`, `espn`) using runtime `GITHUB_TOKEN`/`GH_TOKEN`, sets `GOPRIVATE` and `GIT_ASKPASS` when tokens are present, redacts sensitive output, and exits with clear non-zero codes when private access or runtime prerequisites are missing. 
- Update `docker-compose.yml` to use `build:` for `app` and `worker` (pointing at the new `Dockerfile`), add `APP_ENV=production`, `HERMES_ENV=prod`, `DATABASE_URL` using host `hermes_db`, and enable the installer by default with `HERMES_INSTALL_PRINTING_PRESS_CLIS=true`, while preserving `container_name` and project volumes and keeping `postgres`/`hermes_db` unchanged. 
- Document the external CLI runtime layer and safe manual retry command in `README.md`. 

### Testing
- Ran `node --check index.js`, `node --check worker.js`, `node --check dispatcher/safety.js`, and `node --check dispatcher/externalCliTools.js`, all of which completed successfully. 
- Validated shell scripts with `bash -n scripts/install-printing-press-clis.sh docker/hermes-entrypoint.sh`, which returned no syntax errors. 
- Performed local repository checks (`git diff --check` / status) with no code-style errors reported. 
- Docker-related steps (`docker-compose build/stop/rm/up`, `docker exec ...` verification, and `curl http://localhost:3000/health`) could not be executed in this environment because Docker/docker-compose are not available, so runtime image build and in-container CLI verification remain to be run in a Docker-capable environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0008d59e6483338ccfbb057c5e6cf1)