### PR TITLE
Implement Hermes Skill Layer v2: explain matches, show skills, event logging, host-tool profiles

### DIFF
--- a/dispatcher/planner.js
+++ b/dispatcher/planner.js
@@ -31,6 +31,13 @@ async function createPlanForTask(task) {
       [plan.id, i + 1, stepTypes[i]]
     );
   }
+  if (task.skill_context) {
+    await query(
+      `insert into hermes_task_events (task_id, event_type, message, payload)
+       values ($1, 'skill_context_attached', $2, $3)`,
+      [task.id, 'Skill Context available to planner', { truncated: task.skill_context.includes('[Skill Context truncated]') }]
+    );
+  }
   console.log('PLAN_CREATED', { taskId: task.id, planId: plan.id });
   return plan;
 }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,17 @@ const axios = require("axios");
 const { query } = require("./db");
 const { canonicalizeApprovalSnapshot, hashApprovalSnapshot, normalizeInputText } = require("./approvalSnapshot");
 const { getSystemHealth } = require("./dispatcher/health");
-const { formatSkillsList, formatSkillMatches, classifyTelegramSkillIntent } = require("./skills/registry");
+const {
+  formatSkillsList,
+  formatSkillMatches,
+  formatSkillShow,
+  formatSkillWhy,
+  formatSkillDoctor,
+  classifyTelegramSkillIntent,
+  matchSkills,
+  checkSkillRequirements,
+  buildSkillContext,
+} = require("./skills/registry");
 const {
   ensureGBrainSchema,
   learnFromText,
@@ -683,16 +693,31 @@ function buildUnknownTelegramReply(text) {
 
 
 
-function buildSkillsCommandReply(text) {
+async function buildSkillsCommandReply(text) {
   const input = String(text || "").trim();
   if (/^\/skills(?:@\w+)?\s+list$/i.test(input) || /^\/skills(?:@\w+)?$/i.test(input)) {
-    return `Curated Hermes Skill Pack v1\n\n${formatSkillsList()}\n\nRouting: classify intent → match top 1-3 skills → check env/tools → load selected SKILL.md only → plan → require approval for risky/prod actions → execute → verify → save lessons.`;
+    return `Curated Hermes Skill Pack v2\n\n${formatSkillsList()}\n\nRouting: classify intent → match top 1-3 skills → check env/tools → load selected SKILL.md only → plan → require approval for risky/prod actions → execute → verify → save lessons.`;
   }
 
-  const match = input.match(/^\/skills(?:@\w+)?\s+match\s+([\s\S]+)$/i);
-  if (!match) {
-    return "Dùng: /skills list hoặc /skills match <task>";
+  const showMatch = input.match(/^\/skills(?:@\w+)?\s+show\s+([\s\S]+)$/i);
+  if (showMatch) return formatSkillShow(showMatch[1].trim());
+
+  const whyMatch = input.match(/^\/skills(?:@\w+)?\s+why\s+([\s\S]+)$/i);
+  if (whyMatch) {
+    const queryText = whyMatch[1].trim();
+    if (!queryText) return "Dùng: /skills why <task>";
+    const routed = classifyTelegramSkillIntent(queryText);
+    if (routed.intent === "small_talk") return "Small-talk detected: no heavy task flow and no SKILL.md loaded.";
+    return formatSkillWhy(queryText, { limit: 3 });
   }
+
+  if (/^\/skills(?:@\w+)?\s+doctor$/i.test(input)) return formatSkillDoctor();
+
+  const learnMatch = input.match(/^\/skills(?:@\w+)?\s+learn(?:\s+([\s\S]+))?$/i);
+  if (learnMatch) return "Skill learning is not implemented yet in Skill Layer v2. Use /task <id> to inspect lesson candidates.";
+
+  const match = input.match(/^\/skills(?:@\w+)?\s+match\s+([\s\S]+)$/i);
+  if (!match) return "Dùng: /skills list | show <name> | why <task> | match <task> | doctor | learn <task_id>";
 
   const queryText = match[1].trim();
   if (!queryText) return "Dùng: /skills match <task>";
@@ -964,6 +989,54 @@ function isAllowed(userId) {
 }
 
 
+async function logSkillUsageForTask(taskId, text) {
+  const routed = classifyTelegramSkillIntent(text);
+  if (routed.intent === "small_talk") return;
+  const selected = matchSkills(text, 3);
+  if (!selected.length) return;
+  const selectedSkills = selected.map((skill) => ({ name: skill.name, score: skill.score }));
+  const requirementDetails = selected.map((skill) => {
+    const req = checkSkillRequirements(skill, process.env);
+    return {
+      name: skill.name,
+      missingEnv: req.missingEnv,
+      missingTools: req.missingTools,
+      hostOperatorTools: req.hostOperatorTools,
+      toolStatuses: (req.toolStatuses || []).map((tool) => ({ tool: tool.tool, kind: tool.kind, status: tool.status, availableInContainer: tool.availableInContainer })),
+      ok: req.ok,
+    };
+  });
+  const missingEnv = [...new Set(requirementDetails.flatMap((item) => item.missingEnv || []))];
+  const missingTools = [...new Set(requirementDetails.flatMap((item) => item.missingTools || []))];
+  const context = buildSkillContext(text, { limit: 3 });
+  await query(
+    `insert into hermes_task_events (task_id, event_type, message, payload) values ($1, 'skills_matched', $2, $3)`,
+    [taskId, 'Skills matched for task planning', { selected_skills: selectedSkills }]
+  );
+  await query(
+    `insert into hermes_task_events (task_id, event_type, message, payload) values ($1, 'skill_requirements_checked', $2, $3)`,
+    [taskId, 'Skill requirements checked', { selected_skills: selectedSkills, requirements: requirementDetails, missing_env: missingEnv, missing_tools: missingTools }]
+  );
+  if (missingEnv.length || missingTools.length) {
+    await query(
+      `insert into hermes_task_events (task_id, event_type, message, payload) values ($1, 'skill_missing_requirements', $2, $3)`,
+      [taskId, 'Skill requirements missing or operator-only', { selected_skills: selectedSkills, missing_env: missingEnv, missing_tools: missingTools }]
+    );
+  }
+  if (context.loadedCustomSkillPaths.length) {
+    await query(
+      `insert into hermes_task_events (task_id, event_type, message, payload) values ($1, 'skill_loaded', $2, $3)`,
+      [taskId, 'Custom skill context loaded', { selected_skills: selectedSkills, loaded_custom_skill_paths: context.loadedCustomSkillPaths }]
+    );
+  }
+  if (context.text) {
+    await query(
+      `insert into hermes_task_events (task_id, event_type, message, payload) values ($1, 'skill_context_attached', $2, $3)`,
+      [taskId, 'Skill context attached to planning context', { selected_skills: selectedSkills, loaded_custom_skill_paths: context.loadedCustomSkillPaths, truncated: context.truncated }]
+    );
+  }
+}
+
 async function createTask(chatId, userId, text, options = {}) {
   const normalized = normalizeInputText(text);
   const dedupeSalt = options.idempotencySalt ? `:${options.idempotencySalt}` : "";
@@ -1014,6 +1087,7 @@ async function createTask(chatId, userId, text, options = {}) {
      values ($1, 'planned', $2)`,
     [taskId, "Task moved to planned"]
   );
+  await logSkillUsageForTask(taskId, text);
   const plannedToPending = await query(
     `update hermes_tasks
      set status='pending_approval',
@@ -1557,9 +1631,9 @@ if (callback) {
       }
 
 
-      if (normalized === "/skills" || normalized === "/skills list" || normalized.startsWith("/skills match ")) {
+      if (normalized === "/skills" || normalized === "/skills list" || normalized.startsWith("/skills match ") || normalized.startsWith("/skills show ") || normalized.startsWith("/skills why ") || normalized === "/skills doctor" || normalized.startsWith("/skills learn")) {
         try {
-          await sendTelegramMessage(chatId, buildSkillsCommandReply(text));
+          await sendTelegramMessage(chatId, await buildSkillsCommandReply(text));
         } catch (err) {
           await sendTelegramMessage(chatId, `Lỗi /skills: ${truncateForTelegram(err.message, 200)}`);
         }

--- a/skills/registry.js
+++ b/skills/registry.js
@@ -13,6 +13,21 @@ const CUSTOM_SKILL_NAMES = [
   "huong-cafe-daily-cashier-report",
 ];
 
+const TOOL_CAPABILITY_PROFILE = Object.freeze({
+  docker: { kind: "host_tool", hostStatus: "requires_host_operator" },
+  psql: { kind: "host_or_container_tool", hostStatus: "requires_host_operator" },
+  git: { kind: "container_tool" },
+  node: { kind: "container_tool" },
+  npm: { kind: "container_tool" },
+  rg: { kind: "container_tool" },
+  gh: { kind: "external_or_container_tool" },
+  codex: { kind: "external_or_container_tool" },
+  "google-workspace": { kind: "external_tool", env: ["GOOGLE_APPLICATION_CREDENTIALS"] },
+});
+
+const SKILL_CONTEXT_MAX_CHARS = 4500;
+const TELEGRAM_SKILL_OUTPUT_MAX_CHARS = 3200;
+
 const CURATED_SKILLS = [
   { name: "hermes-agent", category: "CORE_AGENT", description: "Operate the custom Hermes Node.js agent safely.", keywords: ["hermes", "agent", "node", "worker", "operator"], tools: ["node"], env: [] },
   { name: "hermes-agent-skill-authoring", category: "CORE_AGENT", description: "Author small procedural Hermes skills without loading the full public catalog.", keywords: ["skill", "author", "skill.md", "procedure"], tools: [], env: [] },
@@ -34,7 +49,7 @@ const CURATED_SKILLS = [
   { name: "github-repo-management", category: "CODE_GITHUB", description: "Inspect and maintain GitHub repo settings and branches.", keywords: ["repo", "branch", "github", "manage"], tools: ["git"], env: ["GITHUB_TOKEN"] },
   { name: "codebase-inspection", category: "CODE_GITHUB", description: "Inspect repo structure before editing code.", keywords: ["inspect", "codebase", "repo", "find"], tools: ["rg", "git"], env: [] },
 
-  { name: "google-workspace", category: "BUSINESS_OPS", description: "Work with Google Sheets/Docs/Drive when credentials are available.", keywords: ["google", "sheet", "sheets", "docs", "drive", "cashier", "report"], tools: [], env: ["GOOGLE_APPLICATION_CREDENTIALS"] },
+  { name: "google-workspace", category: "BUSINESS_OPS", description: "Work with Google Sheets/Docs/Drive when credentials are available.", keywords: ["google", "sheet", "sheets", "docs", "drive", "cashier", "report"], tools: ["google-workspace"], env: ["GOOGLE_APPLICATION_CREDENTIALS"] },
   { name: "maps", category: "BUSINESS_OPS", description: "Use maps/location workflows for business ops.", keywords: ["maps", "location", "route", "place"], tools: [], env: [] },
   { name: "ocr-and-documents", category: "BUSINESS_OPS", description: "Extract text from images and operational documents.", keywords: ["ocr", "document", "receipt", "invoice", "scan"], tools: [], env: [] },
   { name: "nano-pdf", category: "BUSINESS_OPS", description: "Create or inspect compact PDF outputs.", keywords: ["pdf", "export", "document"], tools: [], env: [] },
@@ -55,58 +70,106 @@ const CURATED_SKILLS = [
   { name: "approval-snapshot-safety", category: "CUSTOM", description: "Preserve approval snapshot hashing and explicit approval boundaries.", keywords: ["approval", "snapshot", "hash", "approve", "risk"], tools: [], env: [] },
   { name: "somewhere-booking-debug", category: "CUSTOM", description: "Debug Somewhere Staycation booking/admin/timezone flows.", keywords: ["somewhere", "staycation", "booking", "timezone", "calendar", "supabase"], tools: ["git"], env: ["NEXT_PUBLIC_SUPABASE_URL"] },
   { name: "somewhere-payment-admin-debug", category: "CUSTOM", description: "Debug Somewhere payOS payment, webhook, and admin flows.", keywords: ["somewhere", "payment", "payos", "qr", "webhook", "admin", "supabase"], tools: ["git"], env: ["PAYOS_CLIENT_ID", "PAYOS_API_KEY", "PAYOS_CHECKSUM_KEY"] },
-  { name: "huong-cafe-daily-cashier-report", category: "CUSTOM", description: "Build Hưởng Café/Kitchen daily cashier reports in Google Sheets.", keywords: ["huong", "hưởng", "cafe", "kitchen", "cashier", "daily report", "google sheet", "sop", "menu"], tools: [], env: ["GOOGLE_APPLICATION_CREDENTIALS"] },
+  { name: "huong-cafe-daily-cashier-report", category: "CUSTOM", description: "Build Hưởng Café/Kitchen daily cashier reports in Google Sheets.", keywords: ["huong", "hưởng", "cafe", "kitchen", "cashier", "daily report", "google sheet", "sop", "menu"], tools: ["google-workspace"], env: ["GOOGLE_APPLICATION_CREDENTIALS"] },
 ];
 
 function getSkillRegistry() {
-  return CURATED_SKILLS.map((skill) => ({ ...skill }));
+  return CURATED_SKILLS.map((skill) => ({ ...skill, keywords: [...(skill.keywords || [])], tools: [...(skill.tools || [])], env: [...(skill.env || [])] }));
+}
+
+function analyzeSkillMatch(skill, queryText) {
+  const q = String(queryText || "").toLowerCase();
+  const nameParts = skill.name.split(/[-_]/).filter(Boolean);
+  const matchedNameParts = nameParts.filter((part) => q.includes(part));
+  const matchedKeywords = (skill.keywords || []).filter((keyword) => q.includes(keyword.toLowerCase()));
+  const descHits = skill.description.toLowerCase().split(/\W+/).filter((word) => word.length > 4 && q.includes(word));
+  const boosts = [];
+  let workflowBoost = 0;
+
+  if (/docker\s+compose/.test(q) && q.includes("postgres") && q.includes("deploy")) {
+    if (["vps-deploy-runbook", "docker-compose-v1-safety", "postgres-recovery-runbook", "systematic-debugging"].includes(skill.name)) {
+      const boost = skill.name === "vps-deploy-runbook" ? 4 : skill.name === "docker-compose-v1-safety" ? 18 : skill.name === "postgres-recovery-runbook" ? 14 : 20;
+      workflowBoost += boost;
+      boosts.push(`docker-compose postgres deploy +${boost}`);
+    }
+  }
+  if ((q.includes(" pr") || q.includes("pull request")) && skill.name === "github-pr-workflow") { workflowBoost += 16; boosts.push("pull-request workflow +16"); }
+  if (q.includes("booking") && q.includes("timezone") && skill.name === "somewhere-booking-debug") { workflowBoost += 12; boosts.push("booking timezone +12"); }
+  if (q.includes("cashier") && q.includes("google") && skill.name === "google-workspace") { workflowBoost += 10; boosts.push("cashier google +10"); }
+  if (q.includes("cashier") && (q.includes("sheet") || q.includes("report")) && skill.name === "huong-cafe-daily-cashier-report") { workflowBoost += 10; boosts.push("cashier report +10"); }
+
+  const nameScore = matchedNameParts.length * 3;
+  const keywordScore = matchedKeywords.length * 4;
+  const descScore = descHits.length;
+  return {
+    nameScore,
+    keywordScore,
+    descScore,
+    workflowBoost,
+    boosts,
+    matchedKeywords: [...new Set([...matchedNameParts, ...matchedKeywords])],
+    score: nameScore + keywordScore + descScore + workflowBoost,
+  };
 }
 
 function scoreSkill(skill, queryText) {
-  const q = String(queryText || "").toLowerCase();
-  const nameHits = skill.name.split(/[-_]/).filter((part) => q.includes(part)).length * 3;
-  const keywordHits = skill.keywords.filter((keyword) => q.includes(keyword.toLowerCase())).length * 4;
-  const descHits = skill.description.toLowerCase().split(/\W+/).filter((word) => word.length > 4 && q.includes(word)).length;
-  let workflowBoost = 0;
-
-  if (/docker\s+compose/.test(q) && q.includes("postgres") && q.includes("deploy") && skill.name === "vps-deploy-runbook") workflowBoost += 20;
-  if ((q.includes(" pr") || q.includes("pull request")) && skill.name === "github-pr-workflow") workflowBoost += 16;
-  if (q.includes("booking") && q.includes("timezone") && skill.name === "somewhere-booking-debug") workflowBoost += 12;
-  if (q.includes("cashier") && q.includes("google") && skill.name === "google-workspace") workflowBoost += 10;
-  if (q.includes("cashier") && (q.includes("sheet") || q.includes("report")) && skill.name === "huong-cafe-daily-cashier-report") workflowBoost += 10;
-
-  return nameHits + keywordHits + descHits + workflowBoost;
+  return analyzeSkillMatch(skill, queryText).score;
 }
 
 function matchSkills(queryText, limit = 3) {
   const q = String(queryText || "").trim();
   if (!q) return [];
   const scored = getSkillRegistry()
-    .map((skill) => ({ ...skill, score: scoreSkill(skill, q) }))
+    .map((skill) => ({ ...skill, ...analyzeSkillMatch(skill, q) }))
     .filter((skill) => skill.score > 0)
     .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
   const maxScore = scored[0]?.score || 0;
-  const relevant = scored.filter((skill) => skill.score >= Math.max(8, maxScore * 0.35));
+  const relevant = scored.filter((skill) => skill.score >= Math.max(8, maxScore * 0.25));
   return relevant.slice(0, Math.max(1, Math.min(Number(limit) || 3, 3)));
 }
 
 function toolAvailable(tool) {
   if (!/^[a-z0-9._-]+$/i.test(String(tool || ""))) return false;
   try {
-    execFileSync("sh", ["-lc", `command -v ${tool}`], { stdio: "ignore" });
+    execFileSync("bash", ["--noprofile", "--norc", "-lc", `command -v ${tool}`], { stdio: "ignore", env: process.env });
     return true;
   } catch {
     return false;
   }
 }
 
+function describeToolStatus(tool, env = process.env) {
+  const profile = TOOL_CAPABILITY_PROFILE[tool] || { kind: "container_tool" };
+  const availableInContainer = profile.kind !== "external_tool" && toolAvailable(tool);
+  if (profile.kind === "host_tool") {
+    return { tool, kind: profile.kind, availableInContainer, status: process.env.HERMES_SAFE_HOST_WRAPPER ? "available_via_safe_wrapper" : profile.hostStatus, ok: Boolean(process.env.HERMES_SAFE_HOST_WRAPPER), label: `Host/operator tool required: ${tool}` };
+  }
+  if (profile.kind === "host_or_container_tool") {
+    if (availableInContainer) return { tool, kind: profile.kind, availableInContainer, status: "available_container", ok: true, label: `${tool}: available in container` };
+    return { tool, kind: profile.kind, availableInContainer, status: profile.hostStatus, ok: false, label: `Host/operator tool required: ${tool}` };
+  }
+  if (profile.kind === "external_tool") {
+    const requiredEnv = profile.env || [];
+    const missingEnv = requiredEnv.filter((name) => !env[name]);
+    return { tool, kind: profile.kind, availableInContainer: false, status: missingEnv.length ? "missing_external_credentials" : "external_credentials_configured", ok: missingEnv.length === 0, missingEnv, label: `${tool}: external service${missingEnv.length ? " credentials missing" : " configured"}` };
+  }
+  if (profile.kind === "external_or_container_tool") {
+    return { tool, kind: profile.kind, availableInContainer, status: availableInContainer ? "available_container" : "external_or_container_unavailable", ok: availableInContainer, label: availableInContainer ? `${tool}: available in container` : `${tool}: external/container tool unavailable` };
+  }
+  return { tool, kind: profile.kind, availableInContainer, status: availableInContainer ? "available_container" : "missing_container_tool", ok: availableInContainer, label: availableInContainer ? `${tool}: available in container` : `Missing container tool: ${tool}` };
+}
+
 function checkSkillRequirements(skill, env = process.env) {
   const missingEnv = (skill.env || []).filter((name) => !env[name]);
-  const missingTools = (skill.tools || []).filter((tool) => !toolAvailable(tool));
+  const toolStatuses = (skill.tools || []).map((tool) => describeToolStatus(tool, env));
+  const missingTools = toolStatuses.filter((status) => !status.ok).map((status) => status.tool);
+  const hostOperatorTools = toolStatuses.filter((status) => status.status === "requires_host_operator" || status.status === "available_on_host_unverified").map((status) => status.tool);
   return {
     ok: missingEnv.length === 0 && missingTools.length === 0,
     missingEnv,
     missingTools,
+    hostOperatorTools,
+    toolStatuses,
   };
 }
 
@@ -118,11 +181,60 @@ function classifyTelegramSkillIntent(text) {
   return { intent: "task", skills: matchSkills(normalized, 3) };
 }
 
+function customSkillPath(name, rootDir = process.cwd()) {
+  return join(rootDir, "skills", "custom", name, "SKILL.md");
+}
+
 function loadCustomSkillMarkdown(name, rootDir = process.cwd()) {
   if (!CUSTOM_SKILL_NAMES.includes(name)) return null;
-  const skillPath = join(rootDir, "skills", "custom", name, "SKILL.md");
+  const skillPath = customSkillPath(name, rootDir);
   if (!existsSync(skillPath)) return null;
   return readFileSync(skillPath, "utf8");
+}
+
+function closestSkillNames(name, limit = 3) {
+  const needle = String(name || "").toLowerCase();
+  return getSkillRegistry()
+    .map((skill) => {
+      const hay = skill.name.toLowerCase();
+      const overlap = needle.split(/[-_\s]+/).filter((part) => part && hay.includes(part)).length;
+      const prefix = hay.startsWith(needle.slice(0, Math.min(4, needle.length))) ? 2 : 0;
+      const lengthPenalty = Math.abs(hay.length - needle.length) / 20;
+      return { name: skill.name, score: overlap + prefix - lengthPenalty };
+    })
+    .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
+    .slice(0, limit)
+    .map((item) => item.name);
+}
+
+function capTelegramText(text, max = TELEGRAM_SKILL_OUTPUT_MAX_CHARS) {
+  const value = String(text || "");
+  if (value.length <= max) return { text: value, truncated: false };
+  const firstSection = value.split(/\n##\s+/)[0];
+  const prefix = firstSection.length > 120 ? firstSection : value.slice(0, max - 120);
+  return { text: `${prefix.slice(0, max - 120)}\n\n[Truncated for Telegram safety. Showing first section only.]`, truncated: true };
+}
+
+function formatSkillShow(name, options = {}) {
+  const rootDir = options.rootDir || process.cwd();
+  const wanted = String(name || "").trim();
+  if (!wanted) return "Dùng: /skills show <name>";
+  const skill = getSkillRegistry().find((item) => item.name === wanted);
+  if (!skill) return [`Skill not found: ${wanted}`, `Closest matches: ${closestSkillNames(wanted).join(", ") || "none"}`].join("\n");
+  const md = loadCustomSkillMarkdown(skill.name, rootDir);
+  if (md) {
+    const capped = capTelegramText(md, options.maxChars || TELEGRAM_SKILL_OUTPUT_MAX_CHARS);
+    return [`Custom skill: ${skill.name}`, `Path: ${customSkillPath(skill.name, rootDir)}`, capped.text, capped.truncated ? "Output truncated: true" : "Output truncated: false"].join("\n\n");
+  }
+  return [
+    `Curated metadata-only skill: ${skill.name}`,
+    `Category: ${skill.category}`,
+    `Description: ${skill.description}`,
+    `Keywords: ${(skill.keywords || []).join(", ") || "none"}`,
+    `Required env: ${(skill.env || []).join(", ") || "none"}`,
+    `Required tools: ${(skill.tools || []).join(", ") || "none"}`,
+    "Full SKILL.md is not installed locally; only curated public metadata is available.",
+  ].join("\n");
 }
 
 function formatSkillsList() {
@@ -136,6 +248,11 @@ function formatSkillsList() {
     .join("\n\n");
 }
 
+function formatRequirementStatus(req) {
+  const tools = (req.toolStatuses || []).map((item) => item.label).join("; ") || "none";
+  return `env missing [${req.missingEnv.join(", ") || "none"}], tools [${tools}]`;
+}
+
 function formatSkillMatches(queryText, options = {}) {
   const matches = matchSkills(queryText, options.limit || 3);
   if (!matches.length) return `No curated Hermes skills matched: ${queryText}`;
@@ -143,20 +260,116 @@ function formatSkillMatches(queryText, options = {}) {
   for (const skill of matches) {
     const req = checkSkillRequirements(skill, options.env || process.env);
     lines.push(`- ${skill.name} (${skill.category}) — ${skill.description}`);
-    if (!req.ok) {
-      lines.push(`  Safe failure until requirements exist: missing env [${req.missingEnv.join(", ") || "none"}], missing tools [${req.missingTools.join(", ") || "none"}]`);
-    }
+    if (!req.ok) lines.push(`  Safe failure until requirements exist: ${formatRequirementStatus(req)}`);
   }
   return lines.join("\n");
 }
 
+function formatSkillWhy(queryText, options = {}) {
+  const matches = matchSkills(queryText, options.limit || 3);
+  if (!matches.length) return `No skill match for: ${queryText}`;
+  const lines = [`Skill match explanation for: ${queryText}`];
+  for (const skill of matches) {
+    const req = checkSkillRequirements(skill, options.env || process.env);
+    lines.push(`- ${skill.name} score=${skill.score}`);
+    lines.push(`  matched keywords: ${skill.matchedKeywords?.join(", ") || "none"}`);
+    lines.push(`  category/workflow boost: ${skill.boosts?.join("; ") || "none"}`);
+    lines.push(`  required env/tools: env [${(skill.env || []).join(", ") || "none"}], tools [${(skill.tools || []).join(", ") || "none"}]`);
+    lines.push(`  requirements satisfied: ${req.ok ? "yes" : "no"} (${formatRequirementStatus(req)})`);
+    lines.push(`  full SKILL.md loaded for real task: ${skill.category === "CUSTOM" && Boolean(loadCustomSkillMarkdown(skill.name, options.rootDir || process.cwd())) ? "yes" : "no; metadata only"}`);
+  }
+  return lines.join("\n");
+}
+
+function extractSection(md, heading) {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = String(md || "").match(new RegExp(`^##\\s+${escaped}\\s*\\n([\\s\\S]*?)(?=^##\\s+|$)`, "im"));
+  return match ? match[1].trim() : "";
+}
+
+function buildSkillContext(queryText, options = {}) {
+  const rootDir = options.rootDir || process.cwd();
+  const maxChars = options.maxChars || SKILL_CONTEXT_MAX_CHARS;
+  const selected = matchSkills(queryText, options.limit || 3);
+  const loadedCustomSkillPaths = [];
+  const parts = [];
+  for (const skill of selected) {
+    const md = skill.category === "CUSTOM" ? loadCustomSkillMarkdown(skill.name, rootDir) : null;
+    if (md) {
+      loadedCustomSkillPaths.push(customSkillPath(skill.name, rootDir));
+      parts.push([
+        `### ${skill.name}`,
+        `When to use: ${extractSection(md, "When to Use") || skill.description}`,
+        `Procedure:\n${extractSection(md, "Procedure") || "- Follow existing Hermes safety gates."}`,
+        `Pitfalls:\n${extractSection(md, "Pitfalls") || "- Do not bypass approval or execution validation."}`,
+        `Verification:\n${extractSection(md, "Verification") || "- Verify with the narrowest safe check."}`,
+        `Safety notes:\n${extractSection(md, "Safety/approval notes") || "- Keep approval gates intact; never log secrets."}`,
+      ].join("\n"));
+    } else {
+      parts.push(`### ${skill.name}\nDescription: ${skill.description}\nRequirements: env [${(skill.env || []).join(", ") || "none"}], tools [${(skill.tools || []).join(", ") || "none"}]\nFull SKILL.md: not installed locally; metadata only.`);
+    }
+  }
+  const full = parts.length ? `Skill Context\n${parts.join("\n\n")}` : "";
+  const truncated = full.length > maxChars;
+  return {
+    selectedSkills: selected.map((skill) => ({ name: skill.name, score: skill.score })),
+    loadedCustomSkillPaths,
+    text: truncated ? `${full.slice(0, maxChars)}\n[Skill Context truncated]` : full,
+    truncated,
+  };
+}
+
+function getSkillDoctor(options = {}) {
+  const rootDir = options.rootDir || process.cwd();
+  const customFiles = CUSTOM_SKILL_NAMES.map((name) => ({ name, path: customSkillPath(name, rootDir), readable: Boolean(loadCustomSkillMarkdown(name, rootDir)) }));
+  const containerTools = Object.keys(TOOL_CAPABILITY_PROFILE).filter((tool) => TOOL_CAPABILITY_PROFILE[tool].kind !== "external_tool" && toolAvailable(tool));
+  const hostTools = Object.entries(TOOL_CAPABILITY_PROFILE).filter(([, meta]) => meta.kind === "host_tool" || meta.kind === "host_or_container_tool").map(([tool, meta]) => `${tool}:${meta.hostStatus || "requires_host_operator"}`);
+  const optionalEnvWarnings = ["GOOGLE_APPLICATION_CREDENTIALS", "GITHUB_TOKEN", "GITHUB_OWNER", "GITHUB_REPO"].filter((name) => !(options.env || process.env)[name]);
+  return {
+    totalCuratedSkills: getSkillRegistry().filter((skill) => skill.category !== "CUSTOM").length,
+    totalCustomSkills: CUSTOM_SKILL_NAMES.length,
+    customFiles,
+    registryLoaded: true,
+    envToolCheckerStatus: "ok",
+    availableContainerTools: containerTools,
+    hostToolsOperatorRequired: hostTools,
+    warningsMissingOptionalEnvs: optionalEnvWarnings,
+  };
+}
+
+function formatSkillDoctor(options = {}) {
+  const d = getSkillDoctor(options);
+  return [
+    "Hermes Skill System Doctor",
+    `- Registry loaded: ${d.registryLoaded}`,
+    `- Total curated skills: ${d.totalCuratedSkills}`,
+    `- Total custom skills: ${d.totalCustomSkills}`,
+    `- Custom skill files readable: ${d.customFiles.filter((f) => f.readable).length}/${d.customFiles.length}`,
+    `- Env/tool checker: ${d.envToolCheckerStatus}`,
+    `- Available container tools: ${d.availableContainerTools.join(", ") || "none"}`,
+    `- Host tools operator-required: ${d.hostToolsOperatorRequired.join(", ") || "none"}`,
+    `- Missing optional env names: ${d.warningsMissingOptionalEnvs.join(", ") || "none"}`,
+    "No secret values printed.",
+  ].join("\n");
+}
+
 module.exports = {
   CUSTOM_SKILL_NAMES,
+  TOOL_CAPABILITY_PROFILE,
+  SKILL_CONTEXT_MAX_CHARS,
+  TELEGRAM_SKILL_OUTPUT_MAX_CHARS,
   getSkillRegistry,
+  analyzeSkillMatch,
   matchSkills,
   checkSkillRequirements,
   classifyTelegramSkillIntent,
   loadCustomSkillMarkdown,
+  buildSkillContext,
+  closestSkillNames,
   formatSkillsList,
   formatSkillMatches,
+  formatSkillShow,
+  formatSkillWhy,
+  getSkillDoctor,
+  formatSkillDoctor,
 };

--- a/test/skills.registry.test.js
+++ b/test/skills.registry.test.js
@@ -47,7 +47,7 @@ assert.equal(registryNames.length, expectedCuratedNames.size, "registry names mu
 
 assert.deepEqual(
   matchSkills("fix docker compose postgres deploy issue").map((skill) => skill.name),
-  ["vps-deploy-runbook", "docker-compose-v1-safety"],
+  ["docker-compose-v1-safety", "systematic-debugging", "postgres-recovery-runbook"],
 );
 
 assert.deepEqual(

--- a/test/skills.v2.test.js
+++ b/test/skills.v2.test.js
@@ -1,0 +1,82 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  buildSkillContext,
+  checkSkillRequirements,
+  formatSkillDoctor,
+  formatSkillShow,
+  formatSkillWhy,
+  matchSkills,
+} = require('../skills/registry');
+
+test('/skills show custom skill returns SKILL.md content', () => {
+  const output = formatSkillShow('vps-deploy-runbook', { rootDir: process.cwd(), maxChars: 3200 });
+  assert.match(output, /Custom skill: vps-deploy-runbook/);
+  assert.match(output, /## Procedure/);
+  assert.match(output, /Docker Compose/);
+});
+
+test('/skills show unknown skill gives closest matches', () => {
+  const output = formatSkillShow('unknown-name', { rootDir: process.cwd() });
+  assert.match(output, /Skill not found: unknown-name/);
+  assert.match(output, /Closest matches:/);
+});
+
+test('/skills why explains deterministic docker postgres matches', () => {
+  const output = formatSkillWhy('fix docker compose postgres deploy issue', { env: {} });
+  assert.match(output, /docker-compose-v1-safety/);
+  assert.match(output, /postgres-recovery-runbook/);
+  assert.match(output, /systematic-debugging|vps-deploy-runbook/);
+  assert.match(output, /matched keywords:/);
+  assert.match(output, /category\/workflow boost:/);
+  assert.match(output, /Host\/operator tool required: docker/);
+});
+
+test('docker and psql are host/operator tools when unavailable in container', () => {
+  const req = checkSkillRequirements({ tools: ['docker', 'psql'], env: [] }, {});
+  assert.equal(req.ok, false);
+  assert.deepEqual(req.missingTools, ['docker', 'psql']);
+  assert.match(req.toolStatuses.find((t) => t.tool === 'docker').label, /Host\/operator tool required: docker/);
+  const psql = req.toolStatuses.find((t) => t.tool === 'psql');
+  if (!psql.availableInContainer) assert.match(psql.label, /Host\/operator tool required: psql/);
+});
+
+test('missing GOOGLE_APPLICATION_CREDENTIALS remains safe failure', () => {
+  const req = checkSkillRequirements({ tools: ['google-workspace'], env: ['GOOGLE_APPLICATION_CREDENTIALS'] }, {});
+  assert.equal(req.ok, false);
+  assert.deepEqual(req.missingEnv, ['GOOGLE_APPLICATION_CREDENTIALS']);
+  assert.deepEqual(req.missingTools, ['google-workspace']);
+});
+
+test('skill context is capped and loads only selected custom skills', () => {
+  const context = buildSkillContext('fix docker compose postgres deploy issue', { maxChars: 500 });
+  assert.equal(context.truncated, true);
+  assert.ok(context.text.length <= 540);
+  assert.ok(context.loadedCustomSkillPaths.every((p) => /skills\/custom\/.+\/SKILL\.md$/.test(p)));
+  assert.deepEqual(context.selectedSkills.map((s) => s.name), matchSkills('fix docker compose postgres deploy issue').map((s) => s.name));
+});
+
+test('/skills doctor reports health without secret values', () => {
+  const output = formatSkillDoctor({ env: { GOOGLE_APPLICATION_CREDENTIALS: 'secret-file.json' } });
+  assert.match(output, /Hermes Skill System Doctor/);
+  assert.match(output, /Registry loaded: true/);
+  assert.doesNotMatch(output, /secret-file/);
+});
+
+test('/skills why formatter is lightweight and task-free', () => {
+  const output = formatSkillWhy('fix docker compose postgres deploy issue');
+  assert.match(output, /Skill match explanation/);
+  assert.doesNotMatch(output, /Task created from Telegram/);
+});
+
+test('real task planning code emits skill usage events', () => {
+  const source = require('node:fs').readFileSync(require('node:path').join(process.cwd(), 'index.js'), 'utf8');
+  for (const eventName of ['skills_matched', 'skill_requirements_checked', 'skill_loaded', 'skill_missing_requirements', 'skill_context_attached']) {
+    assert.match(source, new RegExp(eventName));
+  }
+});
+
+test('small-talk still bypasses skill matching/heavy flow', () => {
+  const { classifyTelegramSkillIntent } = require('../skills/registry');
+  assert.deepEqual(classifyTelegramSkillIntent('Hi'), { intent: 'small_talk', skills: [] });
+});

--- a/worker.js
+++ b/worker.js
@@ -17,6 +17,7 @@ const { createPlanForTask, taskType } = require('./dispatcher/planner');
 const { executePlan } = require('./dispatcher/executor');
 const { runDueGoals } = require('./dispatcher/goalRunner');
 const { handleExternalCliTask } = require('./dispatcher/externalCliTools');
+const { buildSkillContext, matchSkills, checkSkillRequirements } = require('./skills/registry');
 
 const rawExecAsync = promisify(exec);
 const { canonicalizeApprovalSnapshot, hashApprovalSnapshot } = require('./approvalSnapshot');
@@ -154,6 +155,50 @@ async function persistBlockedApprovalFailure(task, safeError, approvalStatus) {
   );
   await event(task.id, "failed", safeError, summary);
   await safeNotifyOperator(task, safeError, `❌ Task #${task.id} failed: ${safeError}\n${JSON.stringify(summary)}`);
+}
+
+async function attachSkillContextForWorker(task) {
+  const selected = matchSkills(task.input_text || '', 3);
+  if (!selected.length) return null;
+  const selectedSkills = selected.map((skill) => ({ name: skill.name, score: skill.score }));
+  const requirementDetails = selected.map((skill) => {
+    const req = checkSkillRequirements(skill, process.env);
+    return {
+      name: skill.name,
+      missingEnv: req.missingEnv,
+      missingTools: req.missingTools,
+      hostOperatorTools: req.hostOperatorTools,
+      ok: req.ok,
+    };
+  });
+  const context = buildSkillContext(task.input_text || '', { limit: 3 });
+  await event(task.id, 'skills_matched', 'Worker matched skills for planning', { selected_skills: selectedSkills });
+  await event(task.id, 'skill_requirements_checked', 'Worker checked skill requirements', { selected_skills: selectedSkills, requirements: requirementDetails, missing_env: [...new Set(requirementDetails.flatMap((r) => r.missingEnv || []))], missing_tools: [...new Set(requirementDetails.flatMap((r) => r.missingTools || []))] });
+  if (requirementDetails.some((r) => (r.missingEnv || []).length || (r.missingTools || []).length)) {
+    await event(task.id, 'skill_missing_requirements', 'Skill requirements missing or operator-only', { selected_skills: selectedSkills, missing_env: [...new Set(requirementDetails.flatMap((r) => r.missingEnv || []))], missing_tools: [...new Set(requirementDetails.flatMap((r) => r.missingTools || []))] });
+  }
+  if (context.loadedCustomSkillPaths.length) {
+    await event(task.id, 'skill_loaded', 'Custom skill files loaded for planning', { selected_skills: selectedSkills, loaded_custom_skill_paths: context.loadedCustomSkillPaths });
+  }
+  if (context.text) {
+    await event(task.id, 'skill_context_attached', 'Skill context attached to planner', { selected_skills: selectedSkills, loaded_custom_skill_paths: context.loadedCustomSkillPaths, truncated: context.truncated });
+  }
+  return context;
+}
+
+async function createSkillLessonCandidate(task, status, detail = '') {
+  const text = `${task.input_text || ''}
+${detail || ''}`.toLowerCase();
+  let lesson = '';
+  if (/missing|not found|command.*not|env|credential|google_application_credentials|requires_host_operator|docker|psql/.test(text)) {
+    lesson = 'Potential lesson to save: record the missing env/tool preflight and operator handoff for similar skill-matched tasks.';
+  } else if (/deploy|runtime|worker|health|postgres|docker/.test(text)) {
+    lesson = 'Potential lesson to save: capture the deploy/runtime verification pattern that resolved or diagnosed this task.';
+  } else if (status === 'completed') {
+    lesson = 'Potential lesson to save: reuse the successful verification pattern from this task when the same skill match appears again.';
+  }
+  if (!lesson) return;
+  await event(task.id, 'skill_lesson_candidate', lesson, { status, lesson_candidate: lesson });
 }
 
 async function logAction(taskId, actionName, input, output, status) {
@@ -1235,6 +1280,7 @@ async function processOneTask() {
         confidence_level: 'medium',
       })]);
       await event(task.id, "execution_completed", "External CLI routing completed", { tool: externalCliResult.tool, commands: externalCliResult.commands || [] });
+      await createSkillLessonCandidate(task, finalResult.status, externalCliResult.output || '');
       clearInterval(heartbeatTimer);
       await sendTelegramMessage(task.telegram_chat_id, `Task #${task.id} external CLI result:
 ${String(externalCliResult.output || '').slice(0, 3000)}`, null, task.telegram_user_id);
@@ -1242,6 +1288,8 @@ ${String(externalCliResult.output || '').slice(0, 3000)}`, null, task.telegram_u
     }
 
     await event(task.id, "plan_started", "Planning started");
+    const skillContext = await attachSkillContextForWorker(task);
+    if (skillContext?.text) task.skill_context = skillContext.text;
     const plan = await createPlanForTask(task);
     await event(task.id, "plan_created", "Plan created", { plan_id: plan.id });
     await safeNotifyOperator(task, 'plan_created', `🧠 Task #${task.id}: Đã tạo kế hoạch thực thi.`);
@@ -1256,10 +1304,12 @@ ${String(externalCliResult.output || '').slice(0, 3000)}`, null, task.telegram_u
       await releaseTask(task.id, WORKER_ID, 'completed', JSON.stringify(finalResult));
       await query(`update hermes_tasks set execution_completed_at=now(), duration_ms=extract(epoch from (now()-coalesce(execution_started_at,now())))*1000, result_summary=$2::jsonb where id=$1`, [task.id, JSON.stringify({ task_id: task.id, final_status: 'completed', intent: task.intent || 'execute', approval_status: 'approved', actions_attempted: 0, actions_succeeded: 0, actions_failed: 0, actions: [], key_output: 'Task approved.', safe_error: null, next_operator_action: 'Có thể chạy /task để xem chi tiết.', confidence_level: 'high' })]);
       await event(task.id, "execution_completed", "Execution completed");
+      await createSkillLessonCandidate(task, 'completed', finalResult.output || 'Task approved.');
       await safeNotifyOperator(task, 'execution_completed', `✅ Task #${task.id} hoàn tất.`);
     } else {
       await failTask(task.id, WORKER_ID, (finalResult.issues || []).join('; '), false);
       await event(task.id, "execution_failed", "Execution failed", { issues: finalResult.issues || [] });
+      await createSkillLessonCandidate(task, 'failed', (finalResult.issues || []).join('; '));
       await safeNotifyOperator(task, 'execution_failed', `❌ Task #${task.id} thất bại: ${(finalResult.issues || ['unknown']).join('; ')}`);
     }
 
@@ -1289,6 +1339,7 @@ ${String(externalCliResult.output || '').slice(0, 3000)}`, null, task.telegram_u
     await failTask(task.id, WORKER_ID, errorText, Boolean(debug.retryable));
 
     await event(task.id, "failed", errorText, enriched);
+    await createSkillLessonCandidate(task, 'failed', errorText);
     await sendTelegramMessage(task.telegram_chat_id, `Plan failed at step ${session.current_step_id || '-'}`, null, task.telegram_user_id).catch(()=>{});
     await sendTelegramMessage(task.telegram_chat_id, `Task #${task.id} result:
 ${JSON.stringify(enriched)}`, null, task.telegram_user_id);


### PR DESCRIPTION
### Motivation
- Improve how Hermes reasons about and surfaces skill matches so operators see why a skill was chosen and whether requirements are satisfied.
- Allow operators to inspect local custom `SKILL.md` safely via Telegram while keeping lightweight match/why flows out of the heavy task pipeline.
- Record skill usage and lessons per-task to enable future operator review without changing FSM, approvals, or secrets handling.
- Be conservative about tool capability (container vs host vs external) to avoid hallucinating host tools inside worker containers.

### Description
- Add a richer skill registry in `skills/registry.js` with `TOOL_CAPABILITY_PROFILE`, deterministic match analysis (`analyzeSkillMatch` / `scoreSkill`), `formatSkillShow`, `formatSkillWhy`, `formatSkillDoctor`, capped Telegram output, closest-match suggestions, and `buildSkillContext` that caps and loads only selected custom `SKILL.md` files.
- Add Telegram command handling in `index.js` for `/skills show <name>`, `/skills why <task>`, `/skills doctor` and a `/skills learn` placeholder, keep `/skills list` and `/skills match` intact, and ensure `/skills why` remains lightweight and does not create tasks or trigger worker flows.
- Log skill usage lifecycle events into `hermes_task_events` during task creation/planning via `logSkillUsageForTask` (`skills_matched`, `skill_requirements_checked`, `skill_missing_requirements`, `skill_loaded`, `skill_context_attached`) with safe metadata (selected skill names/scores, missing env/tool names, loaded custom paths, truncated flag) and no secret values.
- Attach concise, capped skill context to planner/worker flows by adding `attachSkillContextForWorker` in `worker.js`, persist a `skill_context_attached` event in `dispatcher/planner.js` when available, and avoid loading all skills into every prompt.
- Capture lesson candidates after task completion/failure by emitting `skill_lesson_candidate` events (no automatic SKILL.md edits or memory writes) in `worker.js`.
- Preserve safety gates: small-talk still bypasses heavy flow, approval snapshot/approval gating unchanged, no secrets written to events, and host tools like `docker`/`psql` are reported as operator-required unless a safe wrapper exists.
- Tests: add `test/skills.v2.test.js` and update `test/skills.registry.test.js` expectations to reflect deterministic v2 matching and tool classification.

### Testing
- Ran static checks: `node -c index.js`, `node -c skills/registry.js`, and `node -c worker.js` and they succeeded.
- Ran unit tests: `node --test test/env.staging.test.js test/skills.registry.test.js test/skills.v2.test.js` and all new and existing tests passed (12 tests total, 0 failures).
- Performed registry/formatter smoke checks for Telegram commands (locally invoking `formatSkillShow`, `formatSkillWhy`, `formatSkillDoctor`, `/skills list`) and verified outputs, and confirmed `/skills why` did not create tasks.
- Runtime notes: `docker` is not available in this environment so `docker`-related live restarts could not be executed here and `curl http://localhost:3000/health` did not connect because the app was not running in this sandbox; no DB volumes or secrets were modified during testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0011c363888333a4aac3e564ee94c9)