### PR TITLE
Fix external CLI approval action mismatch

### DIFF
--- a/approvalSnapshot.js
+++ b/approvalSnapshot.js
@@ -14,6 +14,14 @@ function toStringArray(value) {
   return value.map((item) => String(item));
 }
 
+function toPlanArray(value) {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => {
+    if (item && typeof item === 'object') return sortKeysDeep(item);
+    return String(item);
+  });
+}
+
 function sortKeysDeep(value) {
   if (Array.isArray(value)) return value.map(sortKeysDeep);
   if (!value || typeof value !== 'object') return value;
@@ -29,13 +37,15 @@ function canonicalizeApprovalSnapshot({ taskId, payload, inputText, intent, appE
   const canonical = {
     action_list: toStringArray(source.action_list),
     app_env: String(source.app_env || appEnv || 'development'),
-    execution_plan: toStringArray(source.execution_plan),
+    execution_plan: toPlanArray(source.execution_plan),
     intent: String(source.intent || intent || ''),
     memory_ids_used: toStringArray(source.memory_ids_used),
     normalized_input: String(source.normalized_input || normalizeInputText(inputText)),
     risk_level: String(source.risk_level || 'unknown'),
     task_id: String(taskId),
   };
+  if (source.tool !== undefined) canonical.tool = String(source.tool || '');
+  if (source.tool_label !== undefined) canonical.tool_label = String(source.tool_label || '');
   return sortKeysDeep(canonical);
 }
 

--- a/dispatcher/externalCliTools.js
+++ b/dispatcher/externalCliTools.js
@@ -97,15 +97,99 @@ function buildPlan(tool, commands) {
 }
 
 function parseSafeRequestedCommands(text = '', routedToolName = null) {
-  const lower = String(text || '').toLowerCase();
+  const source = String(text || '');
   const commands = [];
   for (const name of TOOL_NAMES) {
     if (routedToolName && name !== routedToolName) continue;
-    if (lower.includes(`command -v ${name}`)) commands.push(`command -v ${name}`);
-    if (lower.includes(`${name} --help | head -40`)) commands.push(`${name} --help | head -40`);
-    if (lower.includes(`${name} --agent`)) commands.push(`${name} --agent`);
+    const escaped = name.replace(/[-/\^$*+?.()|[\]{}]/g, '\\$&');
+    const commandV = new RegExp(`(?:^|[^\\w-])(command\\s+-v\\s+${escaped})(?=$|[^\\w-])`, 'ig');
+    const help = new RegExp(`(?:^|[^\\w-])(${escaped}\\s+--help\\s+\\|\\s+head\\s+-([1-9]\\d?))(?=$|[^\\w-])`, 'ig');
+    const agent = new RegExp(`(?:^|[^\\w-])(${escaped}\\s+--agent\\s+\\|\\s+head\\s+-([1-9]\\d?))(?=$|[^\\w-])`, 'ig');
+
+    for (const match of source.matchAll(commandV)) commands.push(`command -v ${name}`);
+    for (const match of source.matchAll(help)) {
+      const lines = Number(match[2]);
+      if (lines >= 1 && lines <= 80) commands.push(`${name} --help | head -${lines}`);
+    }
+    for (const match of source.matchAll(agent)) {
+      const lines = Number(match[2]);
+      if (lines >= 1 && lines <= 80) commands.push(`${name} --agent | head -${lines}`);
+    }
   }
   return [...new Set(commands)];
+}
+
+function findUnsafeExternalCliCommandMentions(text = '', routedToolName = null) {
+  const source = String(text || '');
+  const safeCommands = new Set(parseSafeRequestedCommands(source, routedToolName));
+  const unsafe = [];
+  for (const name of TOOL_NAMES) {
+    if (routedToolName && name !== routedToolName) continue;
+    const escaped = name.replace(/[-/\^$*+?.()|[\]{}]/g, '\\$&');
+    const directCommand = new RegExp(`(?:^|[\\s;&|])(${escaped}\\s+(?:--(?!help\\b|agent\\b)[^.;,\\n]+|(?:enrich|search|run|fetch|lookup|scrape|send|book|print)\\b[^.;,\\n]*))`, 'ig');
+    for (const match of source.matchAll(directCommand)) {
+      const candidate = match[1].trim().replace(/\s+/g, ' ');
+      if (!safeCommands.has(candidate) && !parseAllowedSmokeCommand(candidate)) unsafe.push(candidate);
+    }
+  }
+  return [...new Set(unsafe)];
+}
+
+function buildExternalCliApprovalPlan(text = '') {
+  if (!isExternalCliTask(text) || mentionsNoRun(text)) return null;
+  const tool = routeTool(text);
+  if (!tool) return null;
+  const commands = parseSafeRequestedCommands(text, tool.name);
+  const unsafeCommands = findUnsafeExternalCliCommandMentions(text, tool.name);
+  if (commands.length === 0 || unsafeCommands.length > 0) {
+    return {
+      ok: false,
+      intent: 'external_cli',
+      tool: tool.name,
+      tool_label: tool.label,
+      commands,
+      unsafe_commands: unsafeCommands,
+      plan: buildPlan(tool, commands),
+      error: unsafeCommands.length > 0 ? 'unsafe_external_cli_command_requested' : 'no_safe_external_cli_commands_requested',
+    };
+  }
+  return {
+    ok: true,
+    intent: 'external_cli',
+    tool: tool.name,
+    tool_label: tool.label,
+    commands,
+    unsafe_commands: [],
+    plan: buildPlan(tool, commands),
+  };
+}
+
+function approvedExternalCliActionsFromSnapshot(snapshot = {}) {
+  const payload = snapshot?.payload && typeof snapshot.payload === 'object' ? snapshot.payload : snapshot;
+  if ((payload.intent || payload.task_intent) !== 'external_cli') return null;
+  return Array.isArray(payload.action_list) ? payload.action_list : [];
+}
+
+function ensureApprovedExternalCliActions(runtimeCommands = [], approvedCommands = []) {
+  const runtime = Array.isArray(runtimeCommands) ? runtimeCommands : [];
+  const approved = Array.isArray(approvedCommands) ? approvedCommands : [];
+  const same = runtime.length === approved.length && runtime.every((cmd, idx) => cmd === approved[idx]);
+  if (!same) {
+    const err = new Error('external_cli_action_mismatch');
+    err.code = 'external_cli_action_mismatch';
+    err.runtimeCommands = runtime;
+    err.approvedCommands = approved;
+    throw err;
+  }
+  for (const command of runtime) {
+    if (!parseAllowedSmokeCommand(command)) {
+      const err = new Error('external_cli_action_not_allowlisted');
+      err.code = 'external_cli_action_not_allowlisted';
+      err.command = command;
+      throw err;
+    }
+  }
+  return true;
 }
 
 function parseAllowedSmokeCommand(command = '') {
@@ -174,9 +258,10 @@ async function handleExternalCliTask(task, deps) {
   if (!isExternalCliTask(text)) return null;
 
   const tool = routeTool(text);
-  let commands = mentionsNoRun(text) ? [] : parseSafeRequestedCommands(text, tool?.name || null);
-  if (!mentionsNoRun(text) && tool && commands.length === 0) {
-    commands = [`command -v ${tool.name}`, `${tool.name} --help | head -40`];
+  const commands = mentionsNoRun(text) ? [] : parseSafeRequestedCommands(text, tool?.name || null);
+  const approvedCommands = deps.approvedCommands || null;
+  if (approvedCommands) {
+    ensureApprovedExternalCliActions(commands, approvedCommands);
   }
   const plan = buildPlan(tool, commands);
 
@@ -230,6 +315,10 @@ module.exports = {
   isExternalCliTask,
   parseAllowedSmokeCommand,
   parseSafeRequestedCommands,
+  findUnsafeExternalCliCommandMentions,
+  buildExternalCliApprovalPlan,
+  approvedExternalCliActionsFromSnapshot,
+  ensureApprovedExternalCliActions,
   runAllowedSmokeCommand,
   handleExternalCliTask,
 };

--- a/dispatcher/externalCliTools.js
+++ b/dispatcher/externalCliTools.js
@@ -170,6 +170,10 @@ function approvedExternalCliActionsFromSnapshot(snapshot = {}) {
   return Array.isArray(payload.action_list) ? payload.action_list : [];
 }
 
+function approvedExternalActionsFromSnapshot(snapshot = {}) {
+  return approvedExternalCliActionsFromSnapshot(snapshot);
+}
+
 function ensureApprovedExternalCliActions(runtimeCommands = [], approvedCommands = []) {
   const runtime = Array.isArray(runtimeCommands) ? runtimeCommands : [];
   const approved = Array.isArray(approvedCommands) ? approvedCommands : [];
@@ -318,6 +322,7 @@ module.exports = {
   findUnsafeExternalCliCommandMentions,
   buildExternalCliApprovalPlan,
   approvedExternalCliActionsFromSnapshot,
+  approvedExternalActionsFromSnapshot,
   ensureApprovedExternalCliActions,
   runAllowedSmokeCommand,
   handleExternalCliTask,

--- a/dispatcher/externalCliTools.js
+++ b/dispatcher/externalCliTools.js
@@ -126,7 +126,7 @@ function findUnsafeExternalCliCommandMentions(text = '', routedToolName = null) 
   for (const name of TOOL_NAMES) {
     if (routedToolName && name !== routedToolName) continue;
     const escaped = name.replace(/[-/\^$*+?.()|[\]{}]/g, '\\$&');
-    const directCommand = new RegExp(`(?:^|[\\s;&|])(${escaped}\\s+(?:--(?!help\\b|agent\\b)[^.;,\\n]+|(?:enrich|search|run|fetch|lookup|scrape|send|book|print)\\b[^.;,\\n]*))`, 'ig');
+    const directCommand = new RegExp(`(?:^|[\\s;&|])(${escaped}\\s+(?:--[a-z][\\w-]*(?:\\s+\\|\\s*[a-z][\\w-]*\\s+-?\\d+)?|(?:enrich|search|run|fetch|lookup|scrape|send|book|print)\\b[^.;,\\n]*))`, 'ig');
     for (const match of source.matchAll(directCommand)) {
       const candidate = match[1].trim().replace(/\s+/g, ' ');
       if (!safeCommands.has(candidate) && !parseAllowedSmokeCommand(candidate)) unsafe.push(candidate);
@@ -199,15 +199,15 @@ function parseAllowedSmokeCommand(command = '') {
     return { type: 'command-v', tool: match[1] };
   }
 
-  match = trimmed.match(/^([a-z0-9][a-z0-9-]*) --help(?: \| head -(\d{1,2}))?$/);
+  match = trimmed.match(/^([a-z0-9][a-z0-9-]*) --help \| head -(\d{1,2})$/);
   if (match && TOOL_NAMES.includes(match[1])) {
-    const lines = match[2] ? Number(match[2]) : 80;
+    const lines = Number(match[2]);
     if (lines >= 1 && lines <= 80) return { type: 'help', tool: match[1], lines };
   }
 
-  match = trimmed.match(/^([a-z0-9][a-z0-9-]*) --agent(?: \| head -(\d{1,2}))?$/);
+  match = trimmed.match(/^([a-z0-9][a-z0-9-]*) --agent \| head -(\d{1,2})$/);
   if (match && TOOL_NAMES.includes(match[1])) {
-    const lines = match[2] ? Number(match[2]) : 80;
+    const lines = Number(match[2]);
     if (lines >= 1 && lines <= 80) return { type: 'agent', tool: match[1], lines };
   }
 

--- a/dispatcher/goals.js
+++ b/dispatcher/goals.js
@@ -1,0 +1,7 @@
+const { executeGoal } = require('./goalRunner');
+
+async function runGoalTask(goal) {
+  return executeGoal(goal);
+}
+
+module.exports = { runGoalTask };

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const {
   buildAudit,
   buildDeployCheck,
 } = require("./gbrain");
-const { isExternalCliTask, routeTool } = require('./dispatcher/externalCliTools');
+const { isExternalCliTask, routeTool, buildExternalCliApprovalPlan } = require('./dispatcher/externalCliTools');
 const app = express();
 app.use(express.json());
 
@@ -971,27 +971,46 @@ async function createTask(chatId, userId, text, options = {}) {
     .createHash("sha256")
     .update(`${userId}:${normalized}${dedupeSalt}`)
     .digest("hex");
+  const externalCliApproval = buildExternalCliApprovalPlan(text);
+  if (externalCliApproval && !externalCliApproval.ok) {
+    const unsafeText = externalCliApproval.unsafe_commands.length
+      ? ` Unsafe command(s): ${externalCliApproval.unsafe_commands.join(", ")}`
+      : "";
+    throw new Error(`external_cli_command_rejected: ${externalCliApproval.error}.${unsafeText}`);
+  }
+  const approvalIntent = externalCliApproval?.ok ? "external_cli" : "execute";
   const approvalSnapshot = canonicalizeApprovalSnapshot({
     taskId: "",
-    payload: {
-      intent: "execute",
-      normalized_input: normalized,
-      execution_plan: ["parse_intent", "run_gates", "execute_plan"],
-      risk_level: "medium",
-      action_list: ["git status", "npm test", "npm run build"],
-      memory_ids_used: [],
-    },
+    payload: externalCliApproval?.ok
+      ? {
+          intent: "external_cli",
+          normalized_input: normalized,
+          tool: externalCliApproval.tool,
+          tool_label: externalCliApproval.tool_label,
+          execution_plan: externalCliApproval.plan,
+          risk_level: "medium",
+          action_list: externalCliApproval.commands,
+          memory_ids_used: [],
+        }
+      : {
+          intent: "execute",
+          normalized_input: normalized,
+          execution_plan: ["parse_intent", "run_gates", "execute_plan"],
+          risk_level: "medium",
+          action_list: ["git status", "npm test", "npm run build"],
+          memory_ids_used: [],
+        },
     inputText: text,
-    intent: "execute",
+    intent: approvalIntent,
     appEnv: process.env.APP_ENV || "development",
   });
 
   const result = await query(
-    `insert into hermes_tasks (telegram_chat_id, telegram_user_id, input_text, status, idempotency_key)
-     values ($1, $2, $3, 'planned', $4)
+    `insert into hermes_tasks (telegram_chat_id, telegram_user_id, input_text, intent, status, idempotency_key)
+     values ($1, $2, $3, $4, 'planned', $5)
      on conflict (idempotency_key) do update set updated_at=now()
      returning id`,
-    [chatId, userId, text, dedupeKey]
+    [chatId, userId, text, approvalIntent, dedupeKey]
   );
 
   const taskId = result.rows[0].id;
@@ -999,7 +1018,7 @@ async function createTask(chatId, userId, text, options = {}) {
     taskId,
     payload: approvalSnapshot,
     inputText: text,
-    intent: "execute",
+    intent: approvalIntent,
     appEnv: process.env.APP_ENV || "development",
   });
   const approvalSnapshotHash = hashApprovalSnapshot(canonicalApprovalSnapshot);
@@ -1030,7 +1049,8 @@ async function createTask(chatId, userId, text, options = {}) {
      values ($1, 'pending_approval', $2)`,
     [taskId, "Task requires explicit approval before running"]
     );
-    const actionList = Array.isArray(approvalSnapshot.action_list) ? approvalSnapshot.action_list.join(", ") : "-";
+    const actionItems = Array.isArray(approvalSnapshot.action_list) ? approvalSnapshot.action_list : [];
+    const actionList = actionItems.length ? `\n- ${actionItems.join("\n- ")}` : " -";
     const shortHash = approvalSnapshotHash ? approvalSnapshotHash.slice(0, 12) : "-";
     const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
     const approvalMessage = [
@@ -1040,7 +1060,7 @@ async function createTask(chatId, userId, text, options = {}) {
       `Risk: ${approvalSnapshot.risk_level || "-"}`,
       `Expires: ${expiresAt}`,
       `Snapshot: ${shortHash}`,
-      `Actions: ${actionList || "-"}`,
+      `Actions:${actionList || " -"}`,
     ].join("\n");
     try {
       await sendTelegramMessage(chatId, approvalMessage, {
@@ -2367,8 +2387,16 @@ NEXT ACTION:
       }
 
       console.log("DEFAULT_TASK_PATH_ENTERED", { userId, chatId, text });
-      const taskId = await createTask(chatId, userId, text);
-      await sendTelegramMessage(chatId, `Đã nhận task #${taskId}. Hermes đang xử lý...`);
+      try {
+        const taskId = await createTask(chatId, userId, text);
+        await sendTelegramMessage(chatId, `Đã nhận task #${taskId}. Hermes đang xử lý...`);
+      } catch (err) {
+        if (String(err.message || "").startsWith("external_cli_command_rejected:")) {
+          await sendTelegramMessage(chatId, `Rejected external CLI request: ${String(err.message).replace(/^external_cli_command_rejected:\s*/, "")}`);
+          continue;
+        }
+        throw err;
+      }
     }
   } catch (err) {
     console.error("Polling error:", err.response?.data || err.message);

--- a/skills/registry.js
+++ b/skills/registry.js
@@ -110,6 +110,17 @@ function checkSkillRequirements(skill, env = process.env) {
   };
 }
 
+function buildSkillContext(queryText, options = {}) {
+  const skills = matchSkills(queryText, options.limit || 3);
+  return {
+    input: String(queryText || ''),
+    skills: skills.map((skill) => ({
+      ...skill,
+      requirements: checkSkillRequirements(skill, options.env || process.env),
+    })),
+  };
+}
+
 function classifyTelegramSkillIntent(text) {
   const normalized = String(text || "").trim().toLowerCase();
   if (!normalized || ["hi", "hello", "hey", "chào", "chao", "alo", "ok", "ping", "test"].includes(normalized)) {
@@ -155,6 +166,7 @@ module.exports = {
   getSkillRegistry,
   matchSkills,
   checkSkillRequirements,
+  buildSkillContext,
   classifyTelegramSkillIntent,
   loadCustomSkillMarkdown,
   formatSkillsList,

--- a/test/externalCliTools.test.js
+++ b/test/externalCliTools.test.js
@@ -6,11 +6,13 @@ const path = require('node:path');
 
 const {
   buildExternalCliApprovalPlan,
+  parseAllowedSmokeCommand,
   parseSafeRequestedCommands,
   findUnsafeExternalCliCommandMentions,
   ensureApprovedExternalCliActions,
   handleExternalCliTask,
 } = require('../dispatcher/externalCliTools');
+const { canonicalizeApprovalSnapshot, normalizeInputText } = require('../approvalSnapshot');
 
 const smokePrompt = 'Check if company-goat is installed. Only run command -v company-goat and company-goat --help | head -40. Do not run paid enrichment. Do not patch code.';
 const noRunPrompt = 'Use your capability routing inventory. Which tool should handle startup/company diligence? Do not run commands.';
@@ -37,6 +39,23 @@ test('generic git/npm actions are not used for external CLI smoke', () => {
   assert.equal(plan.commands.includes('npm run build'), false);
 });
 
+test('external CLI allowlist requires head for help and agent commands', () => {
+  assert.equal(parseAllowedSmokeCommand('company-goat --help'), null);
+  assert.equal(parseAllowedSmokeCommand('company-goat --agent'), null);
+  assert.deepEqual(parseAllowedSmokeCommand('company-goat --help | head -40'), {
+    type: 'help',
+    tool: 'company-goat',
+    lines: 40,
+  });
+});
+
+test('unsafe help variants without exact head command are rejected', () => {
+  const plan = buildExternalCliApprovalPlan('Check company-goat --help before running anything else.');
+  assert.equal(plan.ok, false);
+  assert.equal(plan.error, 'unsafe_external_cli_command_requested');
+  assert.deepEqual(plan.unsafe_commands, ['company-goat --help']);
+});
+
 test('unsafe external CLI command is rejected', () => {
   const unsafePrompt = 'Use company-goat enrich acme corp. Do not run paid enrichment.';
   const plan = buildExternalCliApprovalPlan(unsafePrompt);
@@ -46,6 +65,34 @@ test('unsafe external CLI command is rejected', () => {
 
   const unsafeMentions = findUnsafeExternalCliCommandMentions('Only run company-goat enrich acme corp.', 'company-goat');
   assert.deepEqual(unsafeMentions, ['company-goat enrich acme corp']);
+});
+
+test('external CLI approval snapshot includes exact actions and structured plan', () => {
+  const plan = buildExternalCliApprovalPlan(smokePrompt);
+  const snapshot = canonicalizeApprovalSnapshot({
+    taskId: 23,
+    payload: {
+      intent: 'external_cli',
+      normalized_input: normalizeInputText(smokePrompt),
+      tool: plan.tool,
+      tool_label: plan.tool_label,
+      execution_plan: plan.plan,
+      risk_level: 'medium',
+      action_list: plan.commands,
+      memory_ids_used: [],
+    },
+    inputText: smokePrompt,
+    intent: 'external_cli',
+    appEnv: 'development',
+  });
+
+  assert.equal(snapshot.intent, 'external_cli');
+  assert.equal(snapshot.tool, 'company-goat');
+  assert.deepEqual(snapshot.action_list, ['command -v company-goat', 'company-goat --help | head -40']);
+  assert.deepEqual(snapshot.execution_plan[2], {
+    commands: ['command -v company-goat', 'company-goat --help | head -40'],
+    step: 'execute_safe_smoke_commands',
+  });
 });
 
 test('worker external CLI guard rejects runtime command list mismatch before execution', () => {

--- a/test/externalCliTools.test.js
+++ b/test/externalCliTools.test.js
@@ -1,0 +1,87 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  buildExternalCliApprovalPlan,
+  parseSafeRequestedCommands,
+  findUnsafeExternalCliCommandMentions,
+  ensureApprovedExternalCliActions,
+  handleExternalCliTask,
+} = require('../dispatcher/externalCliTools');
+
+const smokePrompt = 'Check if company-goat is installed. Only run command -v company-goat and company-goat --help | head -40. Do not run paid enrichment. Do not patch code.';
+const noRunPrompt = 'Use your capability routing inventory. Which tool should handle startup/company diligence? Do not run commands.';
+
+test('no-run external CLI selection creates no executable approval plan', () => {
+  assert.equal(buildExternalCliApprovalPlan(noRunPrompt), null);
+});
+
+test('company-goat smoke approval plan uses exact external CLI actions', () => {
+  const plan = buildExternalCliApprovalPlan(smokePrompt);
+  assert.equal(plan.ok, true);
+  assert.equal(plan.intent, 'external_cli');
+  assert.equal(plan.tool, 'company-goat');
+  assert.deepEqual(plan.commands, [
+    'command -v company-goat',
+    'company-goat --help | head -40',
+  ]);
+});
+
+test('generic git/npm actions are not used for external CLI smoke', () => {
+  const plan = buildExternalCliApprovalPlan(smokePrompt);
+  assert.equal(plan.commands.includes('git status'), false);
+  assert.equal(plan.commands.includes('npm test'), false);
+  assert.equal(plan.commands.includes('npm run build'), false);
+});
+
+test('unsafe external CLI command is rejected', () => {
+  const unsafePrompt = 'Use company-goat enrich acme corp. Do not run paid enrichment.';
+  const plan = buildExternalCliApprovalPlan(unsafePrompt);
+  assert.equal(plan.ok, false);
+  assert.equal(plan.error, 'unsafe_external_cli_command_requested');
+  assert.deepEqual(parseSafeRequestedCommands(unsafePrompt, 'company-goat'), []);
+
+  const unsafeMentions = findUnsafeExternalCliCommandMentions('Only run company-goat enrich acme corp.', 'company-goat');
+  assert.deepEqual(unsafeMentions, ['company-goat enrich acme corp']);
+});
+
+test('worker external CLI guard rejects runtime command list mismatch before execution', () => {
+  assert.throws(
+    () => ensureApprovedExternalCliActions(
+      ['command -v company-goat', 'company-goat --help | head -40'],
+      ['git status', 'npm test', 'npm run build'],
+    ),
+    /external_cli_action_mismatch/,
+  );
+});
+
+test('worker executes only approved external CLI safe commands', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-cli-'));
+  const fakeTool = path.join(tmp, 'company-goat');
+  fs.writeFileSync(fakeTool, '#!/bin/sh\necho "company-goat help line"\n');
+  fs.chmodSync(fakeTool, 0o755);
+  const oldPath = process.env.PATH;
+  process.env.PATH = `${tmp}${path.delimiter}${oldPath || ''}`;
+
+  const logs = [];
+  try {
+    const result = await handleExternalCliTask(
+      { id: 123, input_text: smokePrompt },
+      {
+        approvedCommands: ['command -v company-goat', 'company-goat --help | head -40'],
+        query: async (_sql, params) => { logs.push(params); return { rows: [], rowCount: 1 }; },
+        event: async () => {},
+      },
+    );
+    assert.equal(result.status, 'completed');
+    assert.deepEqual(result.commands, ['command -v company-goat', 'company-goat --help | head -40']);
+    assert.equal(result.results.length, 2);
+    assert.equal(logs.some((params) => JSON.stringify(params).includes('git status')), false);
+  } finally {
+    process.env.PATH = oldPath;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/test/merge.conflicts.test.js
+++ b/test/merge.conflicts.test.js
@@ -14,10 +14,6 @@ test('worker.js resolves external CLI and skill registry import conflict', () =>
   }
   assert.match(
     worker,
-    /const \{ handleExternalCliTask, approvedExternalCliActionsFromSnapshot \} = require\('\.\/dispatcher\/externalCliTools'\);/,
-  );
-  assert.match(
-    worker,
-    /const \{ buildSkillContext, matchSkills, checkSkillRequirements \} = require\('\.\/skills\/registry'\);/,
+    /const \{ runGoalTask \} = require\("\.\/dispatcher\/goals"\);\nconst \{ handleExternalCliTask, approvedExternalActionsFromSnapshot \} = require\("\.\/dispatcher\/externalCliTools"\);\nconst \{ buildSkillContext, matchSkills, checkSkillRequirements \} = require\("\.\/skills\/registry"\);/,
   );
 });

--- a/test/merge.conflicts.test.js
+++ b/test/merge.conflicts.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+const repoRoot = join(__dirname, '..');
+
+test('worker.js resolves external CLI and skill registry import conflict', () => {
+  const worker = readFileSync(join(repoRoot, 'worker.js'), 'utf8');
+
+  const conflictMarkers = ['<' + '<<<<<<', '=' + '======', '>' + '>>>>>>'];
+  for (const marker of conflictMarkers) {
+    assert.equal(worker.includes(marker), false);
+  }
+  assert.match(
+    worker,
+    /const \{ handleExternalCliTask, approvedExternalCliActionsFromSnapshot \} = require\('\.\/dispatcher\/externalCliTools'\);/,
+  );
+  assert.match(
+    worker,
+    /const \{ buildSkillContext, matchSkills, checkSkillRequirements \} = require\('\.\/skills\/registry'\);/,
+  );
+});

--- a/test/merge.conflicts.test.js
+++ b/test/merge.conflicts.test.js
@@ -12,8 +12,14 @@ test('worker.js resolves external CLI and skill registry import conflict', () =>
   for (const marker of conflictMarkers) {
     assert.equal(worker.includes(marker), false);
   }
-  assert.match(
-    worker,
-    /const \{ runGoalTask \} = require\("\.\/dispatcher\/goals"\);\nconst \{ handleExternalCliTask, approvedExternalActionsFromSnapshot \} = require\("\.\/dispatcher\/externalCliTools"\);\nconst \{ buildSkillContext, matchSkills, checkSkillRequirements \} = require\("\.\/skills\/registry"\);/,
-  );
+  const expectedResolvedBlock = [
+    'const { runGoalTask } = require("./dispatcher/goals");',
+    'const { handleExternalCliTask, approvedExternalActionsFromSnapshot } = require("./dispatcher/externalCliTools");',
+    'const { buildSkillContext, matchSkills, checkSkillRequirements } = require("./skills/registry");',
+    '',
+    'const rawExecAsync = promisify(exec);',
+  ].join('\n');
+
+  assert.equal(worker.includes(expectedResolvedBlock), true);
+  assert.equal((worker.match(/handleExternalCliTask/g) || []).length, 2);
 });

--- a/test/skills.registry.test.js
+++ b/test/skills.registry.test.js
@@ -1,6 +1,7 @@
 const assert = require("node:assert/strict");
 const {
   CUSTOM_SKILL_NAMES,
+  buildSkillContext,
   classifyTelegramSkillIntent,
   formatSkillMatches,
   getSkillRegistry,
@@ -54,6 +55,13 @@ assert.deepEqual(
   matchSkills("create PR for booking timezone bug").map((skill) => skill.name),
   ["github-pr-workflow", "somewhere-booking-debug"],
 );
+
+const skillContext = buildSkillContext("create PR for booking timezone bug", { env: {} });
+assert.deepEqual(
+  skillContext.skills.map((skill) => skill.name),
+  ["github-pr-workflow", "somewhere-booking-debug"],
+);
+assert.equal(skillContext.skills[0].requirements.ok, false);
 
 assert.deepEqual(
   matchSkills("make daily cashier report Google Sheet").map((skill) => skill.name),

--- a/worker.js
+++ b/worker.js
@@ -16,8 +16,9 @@ const { handleTaskFailure } = require('./dispatcher/autodebug');
 const { createPlanForTask, taskType } = require('./dispatcher/planner');
 const { executePlan } = require('./dispatcher/executor');
 const { runDueGoals } = require('./dispatcher/goalRunner');
-const { handleExternalCliTask, approvedExternalCliActionsFromSnapshot } = require('./dispatcher/externalCliTools');
-const { buildSkillContext, matchSkills, checkSkillRequirements } = require('./skills/registry');
+const { runGoalTask } = require("./dispatcher/goals");
+const { handleExternalCliTask, approvedExternalActionsFromSnapshot } = require("./dispatcher/externalCliTools");
+const { buildSkillContext, matchSkills, checkSkillRequirements } = require("./skills/registry");
 
 const rawExecAsync = promisify(exec);
 const { canonicalizeApprovalSnapshot, hashApprovalSnapshot } = require('./approvalSnapshot');
@@ -1206,7 +1207,7 @@ async function processOneTask() {
     await event(task.id, "execution_started", "Worker started task");
     await query(`update hermes_tasks set execution_started_at=now(), updated_at=now() where id=$1`, [task.id]);
 
-    const approvedExternalCliCommands = approvedExternalCliActionsFromSnapshot(approvalTask?.approval_snapshot_payload || {});
+    const approvedExternalCliCommands = approvedExternalActionsFromSnapshot(approvalTask?.approval_snapshot_payload || {});
     let externalCliResult;
     try {
       externalCliResult = await handleExternalCliTask(task, { query, event, approvedCommands: approvedExternalCliCommands || [] });

--- a/worker.js
+++ b/worker.js
@@ -16,7 +16,7 @@ const { handleTaskFailure } = require('./dispatcher/autodebug');
 const { createPlanForTask, taskType } = require('./dispatcher/planner');
 const { executePlan } = require('./dispatcher/executor');
 const { runDueGoals } = require('./dispatcher/goalRunner');
-const { handleExternalCliTask } = require('./dispatcher/externalCliTools');
+const { handleExternalCliTask, approvedExternalCliActionsFromSnapshot } = require('./dispatcher/externalCliTools');
 
 const rawExecAsync = promisify(exec);
 const { canonicalizeApprovalSnapshot, hashApprovalSnapshot } = require('./approvalSnapshot');
@@ -1205,7 +1205,25 @@ async function processOneTask() {
     await event(task.id, "execution_started", "Worker started task");
     await query(`update hermes_tasks set execution_started_at=now(), updated_at=now() where id=$1`, [task.id]);
 
-    const externalCliResult = await handleExternalCliTask(task, { query, event });
+    const approvedExternalCliCommands = approvedExternalCliActionsFromSnapshot(approvalTask?.approval_snapshot_payload || {});
+    let externalCliResult;
+    try {
+      externalCliResult = await handleExternalCliTask(task, { query, event, approvedCommands: approvedExternalCliCommands || [] });
+    } catch (err) {
+      if (err.code === 'external_cli_action_mismatch' || err.code === 'external_cli_action_not_allowlisted') {
+        await event(task.id, err.code, 'External CLI command list differed from approved approval snapshot', {
+          runtime_commands: err.runtimeCommands || [],
+          approved_commands: err.approvedCommands || approvedExternalCliCommands || [],
+          command: err.command || null,
+        });
+        await safeNotifyOperator(task, err.code, `🛑 Task #${task.id}: ${err.code}`);
+        await persistBlockedApprovalFailure(task, err.code, 'invalidated');
+        await failTask(task.id, WORKER_ID, err.code, false);
+        clearInterval(heartbeatTimer);
+        return;
+      }
+      throw err;
+    }
     if (externalCliResult) {
       const finalResult = {
         status: externalCliResult.status === 'completed' ? 'completed' : 'failed',

--- a/worker.js
+++ b/worker.js
@@ -17,6 +17,7 @@ const { createPlanForTask, taskType } = require('./dispatcher/planner');
 const { executePlan } = require('./dispatcher/executor');
 const { runDueGoals } = require('./dispatcher/goalRunner');
 const { handleExternalCliTask, approvedExternalCliActionsFromSnapshot } = require('./dispatcher/externalCliTools');
+const { buildSkillContext, matchSkills, checkSkillRequirements } = require('./skills/registry');
 
 const rawExecAsync = promisify(exec);
 const { canonicalizeApprovalSnapshot, hashApprovalSnapshot } = require('./approvalSnapshot');


### PR DESCRIPTION
### Motivation
- External CLI smoke prompts were producing generic `git`/`npm` approval actions instead of the exact safe external CLI commands requested, creating unsafe approvals.
- The system must detect remembered external CLI tasks early, build an approval plan with the exact allowed smoke commands, and prevent any runtime divergence between approved and executed commands.
- Preserve existing safety guarantees: keep approval snapshot hashing, no-run routing, and execution-time validation while rejecting unsafe CLI mentions.

### Description
- Added robust parsing for allowed external CLI smoke commands via `parseSafeRequestedCommands` and strict detection of unsafe mentions with `findUnsafeExternalCliCommandMentions` in `dispatcher/externalCliTools.js`.
- Implemented `buildExternalCliApprovalPlan`, `approvedExternalCliActionsFromSnapshot`, and `ensureApprovedExternalCliActions` to produce/validate an `external_cli` approval intent and exact `action_list` entries (e.g. ``command -v company-goat``, ``company-goat --help | head -40``).
- Updated `createTask` in `index.js` to detect external CLI plans before generating generic actions, set `intent` to ``external_cli`` when appropriate, embed the exact `action_list` and tool metadata in the canonical approval snapshot, and surface rejection messages for unsafe requests.
- Enhanced `worker.js` to extract approved external CLI commands from the approval snapshot and pass them to `handleExternalCliTask`, failing early with `external_cli_action_mismatch` or `external_cli_action_not_allowlisted` if runtime commands differ from the approved list.
- Extended approval snapshot canonicalization in `approvalSnapshot.js` to preserve structured execution plans and tool metadata while keeping hashing semantics intact.
- Added `test/externalCliTools.test.js` covering: no-run selection, exact `company-goat` smoke plan, absence of generic `git`/`npm` fallbacks, unsafe command rejection, worker-side mismatch rejection, and approved safe execution.

### Testing
- Ran static checks: `node --check index.js`, `node --check worker.js`, `node --check dispatcher/externalCliTools.js`, and `node --check approvalSnapshot.js` with no errors.
- Executed unit tests with `node --test`, which ran the new `test/externalCliTools.test.js` and existing `test/skills.registry.test.js` and reported all tests passing (total tests passed: 8).
- Verified behavior manually in unit tests that an acceptance-style smoke prompt (`Check if company-goat is installed...`) yields an approval payload with intent `external_cli` and exact actions `command -v company-goat` and `company-goat --help | head -40` and does not include `git status` / `npm test` / `npm run build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00184ac0048333b24c71e7cd46c9ad)