### PR TITLE
Implement Skill Layer v3: reviewable learn/save-memory and stale task hygiene

### DIFF
--- a/index.js
+++ b/index.js
@@ -694,7 +694,112 @@ function buildUnknownTelegramReply(text) {
 
 
 
-async function buildSkillsCommandReply(text) {
+
+function extractLessonCandidateText(event) {
+  const payload = event?.payload || event?.metadata || {};
+  return payload.lesson_candidate || payload.lesson || event?.message || "";
+}
+
+function summarizeSkillEvents(events) {
+  const summary = { selectedSkills: [], missingEnv: [], missingTools: [] };
+  for (const event of events || []) {
+    const data = event.payload || event.metadata || {};
+    if (Array.isArray(data.selected_skills)) {
+      summary.selectedSkills = data.selected_skills.map((skill) => skill.name || skill).filter(Boolean);
+    }
+    if (Array.isArray(data.selected_skill_names)) summary.selectedSkills = data.selected_skill_names.filter(Boolean);
+    if (Array.isArray(data.missing_env)) summary.missingEnv = data.missing_env.filter(Boolean);
+    if (Array.isArray(data.missing_tools)) summary.missingTools = data.missing_tools.filter(Boolean);
+  }
+  return summary;
+}
+
+async function getSkillLessonReview(taskId, options = {}) {
+  const queryFn = options.queryFn || query;
+  const taskRes = await queryFn(
+    `select id,status,input_text from hermes_tasks where id=$1 limit 1`,
+    [taskId],
+  );
+  const task = taskRes.rows[0];
+  if (!task) return { task: null, candidate: null, events: [] };
+  let eventsRes;
+  try {
+    eventsRes = await queryFn(
+      `select event_type,message,payload,metadata,created_at
+       from hermes_task_events
+       where task_id=$1
+       order by sequence_id desc nulls last, created_at desc, id desc
+       limit 100`,
+      [taskId],
+    );
+  } catch {
+    eventsRes = await queryFn(
+      `select event_type,message,payload,metadata,created_at
+       from hermes_task_events
+       where task_id=$1
+       order by created_at desc, id desc
+       limit 100`,
+      [taskId],
+    );
+  }
+  const events = eventsRes.rows || [];
+  const candidate = events.find((event) => event.event_type === 'skill_lesson_candidate') || null;
+  return { task, candidate, events };
+}
+
+async function buildSkillLearnReviewMessage(taskId, options = {}) {
+  const { task, candidate, events } = await getSkillLessonReview(taskId, options);
+  if (!task) return `Không tìm thấy task #${taskId}.`;
+  if (!candidate) return `No skill_lesson_candidate found for task #${taskId}. Use /events ${taskId} to inspect task history.`;
+  const eventSummary = summarizeSkillEvents(events);
+  const lesson = truncateForTelegram(extractLessonCandidateText(candidate), 900);
+  return [
+    `Skill lesson review for task #${task.id}`,
+    `- Status: ${task.status}`,
+    `- Input: ${truncateForTelegram(task.input_text, 500)}`,
+    `- Selected skills: ${eventSummary.selectedSkills.length ? eventSummary.selectedSkills.join(', ') : '-'}`,
+    `- Missing env: ${eventSummary.missingEnv.length ? eventSummary.missingEnv.join(', ') : '-'}`,
+    `- Missing tools: ${eventSummary.missingTools.length ? eventSummary.missingTools.join(', ') : '-'}`,
+    `Potential lesson to save: ${lesson}`,
+    `Next step: /skills save-memory ${task.id} or /skills append-skill ${task.id} <skill-name>`,
+  ].join("\n");
+}
+
+async function saveSkillLessonToMemory(taskId, options = {}) {
+  const queryFn = options.queryFn || query;
+  const { task, candidate } = await getSkillLessonReview(taskId, { queryFn });
+  if (!task) return { ok: false, message: `Không tìm thấy task #${taskId}.` };
+  if (!candidate) return { ok: false, message: `No skill_lesson_candidate found for task #${taskId}. Nothing saved.` };
+  const lesson = redactSensitiveText(extractLessonCandidateText(candidate));
+  if (!lesson.trim()) return { ok: false, message: `Skill lesson candidate for task #${taskId} is empty. Nothing saved.` };
+  const memoryKey = `skill_lesson:task:${task.id}`;
+  const memoryRes = await queryFn(
+    `insert into hermes_memories (memory_key,memory_text,source,trust_score,memory_type,importance,confidence,last_used_at)
+     values ($1,$2,$3,$4,$5,$6,$7,now())
+     returning id,memory_key,memory_text,memory_type`,
+    [memoryKey, lesson, 'skill_layer_v3_reviewed', 0.7, 'ops_sop', 3, 0.7],
+  );
+  await queryFn(
+    `insert into hermes_task_events (task_id,event_type,message,payload)
+     values ($1,$2,$3,$4::jsonb)`,
+    [task.id, 'skill_lesson_saved_to_memory', 'Reviewed skill lesson saved to hermes_memories', JSON.stringify({ memory_key: memoryKey, memory_id: memoryRes.rows[0]?.id || null })],
+  );
+  return { ok: true, memory: memoryRes.rows[0] || { memory_key: memoryKey, memory_text: lesson, memory_type: 'ops_sop' } };
+}
+
+async function buildSkillSaveMemoryMessage(taskId, options = {}) {
+  const saved = await saveSkillLessonToMemory(taskId, options);
+  if (!saved.ok) return saved.message;
+  return [
+    `Skill lesson saved to memory ✅`,
+    `- Task: #${taskId}`,
+    `- Memory: ${saved.memory.id || saved.memory.memory_key || '-'}`,
+    `- Type: ${saved.memory.memory_type || 'ops_sop'}`,
+    `- Text: ${truncateForTelegram(saved.memory.memory_text, 500)}`,
+  ].join("\n");
+}
+
+async function buildSkillsCommandReply(text, options = {}) {
   const input = String(text || "").trim();
   if (/^\/skills(?:@\w+)?\s+list$/i.test(input) || /^\/skills(?:@\w+)?$/i.test(input)) {
     return `Curated Hermes Skill Pack v2\n\n${formatSkillsList()}\n\nRouting: classify intent → match top 1-3 skills → check env/tools → load selected SKILL.md only → plan → require approval for risky/prod actions → execute → verify → save lessons.`;
@@ -714,11 +819,22 @@ async function buildSkillsCommandReply(text) {
 
   if (/^\/skills(?:@\w+)?\s+doctor$/i.test(input)) return formatSkillDoctor();
 
-  const learnMatch = input.match(/^\/skills(?:@\w+)?\s+learn(?:\s+([\s\S]+))?$/i);
-  if (learnMatch) return "Skill learning is not implemented yet in Skill Layer v2. Use /task <id> to inspect lesson candidates.";
+  const learnMatch = input.match(/^\/skills(?:@\w+)?\s+learn(?:\s+(\d+))?$/i);
+  if (learnMatch) {
+    const taskId = Number(learnMatch[1]);
+    if (!Number.isInteger(taskId) || taskId <= 0) return "Dùng: /skills learn <task_id>";
+    return buildSkillLearnReviewMessage(taskId, options);
+  }
+
+  const saveMemoryMatch = input.match(/^\/skills(?:@\w+)?\s+save-memory(?:\s+(\d+))?$/i);
+  if (saveMemoryMatch) {
+    const taskId = Number(saveMemoryMatch[1]);
+    if (!Number.isInteger(taskId) || taskId <= 0) return "Dùng: /skills save-memory <task_id>";
+    return buildSkillSaveMemoryMessage(taskId, options);
+  }
 
   const match = input.match(/^\/skills(?:@\w+)?\s+match\s+([\s\S]+)$/i);
-  if (!match) return "Dùng: /skills list | show <name> | why <task> | match <task> | doctor | learn <task_id>";
+  if (!match) return "Dùng: /skills list | show <name> | why <task> | match <task> | doctor | learn <task_id> | save-memory <task_id>";
 
   const queryText = match[1].trim();
   if (!queryText) return "Dùng: /skills match <task>";
@@ -731,7 +847,10 @@ async function buildSkillsCommandReply(text) {
 
 function redactSensitiveText(value) {
   return String(value || "")
-    .replace(/(token|apikey|api_key|authorization|password|bearer|secret)\s*[:=]?\s*[^\s,;]+/gi, "$1=[REDACTED]")
+    .replace(/\b[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s:/?#]+:[^\s@/?#]+@/g, (match) => match.replace(/:\/\/[^\s:/?#]+:[^\s@/?#]+@/, "://[REDACTED]@"))
+    .replace(/\b(?:DATABASE_URL|database_url)\s*[:=]\s*[^\s,;]+/gi, "DATABASE_URL=[REDACTED]")
+    .replace(/\b(?:sk|pk|ghp|gho|glpat|xoxb|xoxp)-[A-Za-z0-9_\-]{12,}\b/g, "[REDACTED_API_KEY]")
+    .replace(/(token|apikey|api_key|authorization|password|bearer|secret|client_secret|access_key)\s*[:=]?\s*[^\s,;]+/gi, "$1=[REDACTED]")
     .replace(/postgres(?:ql)?:\/\/[^\s@]+@/gi, "postgres://[REDACTED]@");
 }
 
@@ -883,6 +1002,144 @@ async function buildQueueMessage() {
     `- worker: ${health.worker?.alive ? "alive" : "unknown"}${workerAge !== "-" ? ` (${workerAge} ago)` : ""}`,
     ...healthWarnings.map((w) => `- warning: ${truncateForTelegram(w, 140)}`),
   ].join("\n");
+}
+
+
+function taskAgeSeconds(task, nowMs = Date.now()) {
+  return Math.floor((nowMs - new Date(task.created_at).getTime()) / 1000);
+}
+
+function isTaskStale(task, nowMs = Date.now()) {
+  const ageSeconds = taskAgeSeconds(task, nowMs);
+  if (task.status === 'pending') return ageSeconds > 24 * 3600;
+  if (task.status === 'approved') return ageSeconds > 24 * 3600;
+  if (task.status === 'running') return ageSeconds > 30 * 60;
+  if (task.status === 'pending_approval') {
+    if (task.approval_expires_at && new Date(task.approval_expires_at).getTime() < nowMs) return true;
+    return ageSeconds > 24 * 3600;
+  }
+  return false;
+}
+
+function formatStaleTaskRow(task, nowMs = Date.now()) {
+  const ageSeconds = Number.isFinite(Number(task.age_seconds)) ? Number(task.age_seconds) : taskAgeSeconds(task, nowMs);
+  return `#${task.id} ${task.status} age=${formatAge(ageSeconds)} — ${truncateForTelegram(task.input_text, 90)} | created=${formatIso(task.created_at)}${task.approval_expires_at ? ` | approval_expires=${formatIso(task.approval_expires_at)}` : ''}`;
+}
+
+async function fetchStaleTasks(options = {}) {
+  const queryFn = options.queryFn || query;
+  const res = await queryFn(
+    `select id,status,input_text,created_at,approval_expires_at,
+            extract(epoch from (now() - created_at))::int as age_seconds
+     from hermes_tasks
+     where (status='pending' and created_at < now() - interval '24 hours')
+        or (status='approved' and created_at < now() - interval '24 hours')
+        or (status='running' and created_at < now() - interval '30 minutes')
+        or (status='pending_approval' and (approval_expires_at < now() or (approval_expires_at is null and created_at < now() - interval '24 hours')))
+     order by created_at asc
+     limit $1`,
+    [options.limit || 25],
+  );
+  return res.rows || [];
+}
+
+async function buildTasksStaleMessage(options = {}) {
+  const rows = await fetchStaleTasks(options);
+  if (!rows.length) return 'No stale pending/pending_approval/approved/running tasks found.';
+  return ['Stale tasks (read-only):', ...rows.map((task) => `- ${formatStaleTaskRow(task, options.nowMs)}`)].join('\n');
+}
+
+async function expireStaleTasks(options = {}) {
+  if (!options.operatorAuthorized) {
+    return { ok: false, message: 'Operator authorization required for /tasks expire-stale.' };
+  }
+  const queryFn = options.queryFn || query;
+  const stale = await fetchStaleTasks({ ...options, queryFn, limit: options.limit || 100 });
+  const eligible = stale.filter((task) => task.status === 'pending_approval');
+  const expired = [];
+  const skipped = stale.filter((task) => task.status !== 'pending_approval').map((task) => ({ id: task.id, status: task.status, reason: 'not_expired_in_v3_fsm_guard' }));
+  for (const task of eligible) {
+    const updated = await queryFn(
+      `update hermes_tasks
+       set status='failed', error_text=$2, updated_at=now()
+       where id=$1 and status='pending_approval'
+       returning id,status`,
+      [task.id, 'Expired by operator stale-task cleanup'],
+    );
+    if ((updated.rowCount || 0) !== 1) continue;
+    expired.push(task.id);
+    await queryFn(
+      `insert into hermes_task_events (task_id,event_type,message,payload)
+       values ($1,$2,$3,$4::jsonb)`,
+      [task.id, 'stale_task_expired', 'Expired by operator stale-task cleanup', JSON.stringify({ previous_status: task.status, new_status: 'failed' })],
+    );
+    await queryFn(
+      `insert into hermes_task_events (task_id,event_type,message,payload)
+       values ($1,$2,$3,$4::jsonb)`,
+      [task.id, 'status_transition', 'pending_approval -> failed', JSON.stringify({ reason: 'Expired by operator stale-task cleanup' })],
+    );
+  }
+  return { ok: true, expired, skipped };
+}
+
+async function buildTasksExpireStaleMessage(options = {}) {
+  const result = await expireStaleTasks(options);
+  if (!result.ok) return result.message;
+  const lines = [
+    `Expired stale tasks: ${result.expired.length}`,
+    `- ids: ${result.expired.length ? result.expired.join(', ') : '-'}`,
+  ];
+  if (result.skipped.length) {
+    lines.push(`- skipped by v3 FSM guard: ${result.skipped.map((s) => `#${s.id} ${s.status}`).join(', ')}`);
+  }
+  return lines.join('\n');
+}
+
+async function buildTasksSummaryMessage(options = {}) {
+  const queryFn = options.queryFn || query;
+  const summary = await queryFn(
+    `select
+       coalesce(sum(case when status='pending' then 1 else 0 end),0)::int as pending,
+       coalesce(sum(case when status='pending_approval' then 1 else 0 end),0)::int as pending_approval,
+       coalesce(sum(case when status='approved' then 1 else 0 end),0)::int as approved,
+       coalesce(sum(case when status='running' then 1 else 0 end),0)::int as running,
+       coalesce(sum(case when status='completed' and updated_at > now() - interval '24 hours' then 1 else 0 end),0)::int as completed_24h,
+       coalesce(sum(case when status='failed' and updated_at > now() - interval '24 hours' then 1 else 0 end),0)::int as failed_24h,
+       coalesce(extract(epoch from (now() - min(case when status='pending' then created_at end)))::int,0) as oldest_pending_age_seconds,
+       coalesce(sum(case when status='pending' and created_at < now() - interval '24 hours' then 1 else 0 end),0)::int as stale_pending,
+       coalesce(sum(case when status='pending_approval' and (approval_expires_at < now() or (approval_expires_at is null and created_at < now() - interval '24 hours')) then 1 else 0 end),0)::int as stale_pending_approval,
+       coalesce(sum(case when status='approved' and created_at < now() - interval '24 hours' then 1 else 0 end),0)::int as stale_approved,
+       coalesce(sum(case when status='running' and created_at < now() - interval '30 minutes' then 1 else 0 end),0)::int as stale_running
+     from hermes_tasks`,
+  );
+  const row = summary.rows[0] || {};
+  return [
+    'Tasks summary',
+    `- pending: ${row.pending || 0}`,
+    `- pending_approval: ${row.pending_approval || 0}`,
+    `- approved: ${row.approved || 0}`,
+    `- running: ${row.running || 0}`,
+    `- completed_24h: ${row.completed_24h || 0}`,
+    `- failed_24h: ${row.failed_24h || 0}`,
+    `- oldest pending age: ${formatAge(row.oldest_pending_age_seconds)}`,
+    `- stale pending: ${row.stale_pending || 0}`,
+    `- stale pending_approval: ${row.stale_pending_approval || 0}`,
+    `- stale approved: ${row.stale_approved || 0}`,
+    `- stale running: ${row.stale_running || 0}`,
+  ].join('\n');
+}
+
+async function buildTasksCommandReply(text, options = {}) {
+  const input = String(text || '').trim();
+  if (/^\/tasks(?:@\w+)?\s+stale$/i.test(input)) return buildTasksStaleMessage(options);
+  if (/^\/tasks(?:@\w+)?\s+summary$/i.test(input)) return buildTasksSummaryMessage(options);
+  if (/^\/tasks(?:@\w+)?\s+expire-stale$/i.test(input)) {
+    const operatorAuthorized = Object.prototype.hasOwnProperty.call(options, 'operatorAuthorized')
+      ? options.operatorAuthorized
+      : isAllowed(options.userId);
+    return buildTasksExpireStaleMessage({ ...options, operatorAuthorized });
+  }
+  return 'Dùng: /tasks stale | /tasks summary | /tasks expire-stale';
 }
 
 async function buildTelegramTaskMessage(text) {
@@ -1622,7 +1879,7 @@ if (callback) {
       }
 
 
-      if (normalized === "/skills" || normalized === "/skills list" || normalized.startsWith("/skills match ") || normalized.startsWith("/skills show ") || normalized.startsWith("/skills why ") || normalized === "/skills doctor" || normalized.startsWith("/skills learn")) {
+      if (normalized === "/skills" || normalized === "/skills list" || normalized.startsWith("/skills match ") || normalized.startsWith("/skills show ") || normalized.startsWith("/skills why ") || normalized === "/skills doctor" || normalized.startsWith("/skills learn") || normalized.startsWith("/skills save-memory")) {
         try {
           await sendTelegramMessage(chatId, await buildSkillsCommandReply(text));
         } catch (err) {
@@ -1711,6 +1968,16 @@ if (callback) {
         continue;
       }
 
+      if (normalized === "/tasks" || normalized.startsWith("/tasks ")) {
+        try {
+          await sendTelegramMessage(chatId, await buildTasksCommandReply(text, { userId }));
+        } catch (err) {
+          await sendTelegramMessage(chatId, `Lỗi /tasks: ${truncateForTelegram(err.message, 200)}`);
+        }
+        console.log("COMMAND_HANDLED /tasks", { userId, chatId });
+        continue;
+      }
+
       if (normalized === "/memory stats") {
         try {
           await sendTelegramMessage(chatId, await buildMemoryStatsMessage());
@@ -1793,8 +2060,9 @@ if (callback) {
 
 /status — system health
 /queue — queue summary
+/tasks summary|stale|expire-stale — task hygiene
 /pending — pending approvals
-/skills list|match <task> — curated Hermes Skill Pack v1
+/skills list|match|learn|save-memory — curated Hermes Skill Pack v3
 /task <id> — task details
 /events <id> — task event timeline
 /approve <id> — approve pending task
@@ -2527,6 +2795,16 @@ module.exports = {
   app,
   createTask,
   logSkillUsageForTask,
+  buildSkillsCommandReply,
+  buildSkillLearnReviewMessage,
+  saveSkillLessonToMemory,
+  buildSkillSaveMemoryMessage,
+  buildTasksCommandReply,
+  buildTasksStaleMessage,
+  expireStaleTasks,
+  buildTasksExpireStaleMessage,
+  buildTasksSummaryMessage,
+  isTaskStale,
   isCasualTelegramInput,
   isTaskLikeTelegramInput,
 };

--- a/test/skills.v3.test.js
+++ b/test/skills.v3.test.js
@@ -1,0 +1,154 @@
+process.env.DISABLE_TELEGRAM = 'true';
+process.env.PROJECT_ROOT_PROD = process.env.PROJECT_ROOT_PROD || '/tmp/hermes-prod-root-for-tests';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  buildSkillsCommandReply,
+  buildTasksCommandReply,
+  buildTasksStaleMessage,
+  buildTasksSummaryMessage,
+  expireStaleTasks,
+  saveSkillLessonToMemory,
+} = require('../index');
+
+function skillQueryMock({ candidate = true } = {}) {
+  return async (sql, params) => {
+    if (/from hermes_tasks/.test(sql)) {
+      return { rows: [{ id: params[0], status: 'failed', input_text: 'deploy failed with missing docker env' }], rowCount: 1 };
+    }
+    if (/from hermes_task_events/.test(sql)) {
+      return {
+        rows: [
+          { event_type: 'skill_lesson_candidate', message: candidate ? 'Potential lesson to save: use docker preflight token=abc123 DATABASE_URL=postgres://user:pass@db/app https://user:pass@example.com sk-test_1234567890123456' : '', payload: candidate ? { lesson_candidate: 'Use docker preflight token=abc123 DATABASE_URL=postgres://user:pass@db/app https://user:pass@example.com sk-test_1234567890123456' } : {} },
+          { event_type: 'skill_requirements_checked', payload: { missing_env: ['GOOGLE_APPLICATION_CREDENTIALS'], missing_tools: ['docker', 'psql'] } },
+          { event_type: 'skills_matched', payload: { selected_skills: [{ name: 'docker-compose-v1-safety' }] } },
+        ].filter((event) => candidate || event.event_type !== 'skill_lesson_candidate'),
+        rowCount: candidate ? 3 : 2,
+      };
+    }
+    throw new Error(`unexpected sql: ${sql}`);
+  };
+}
+
+test('/skills learn <task_id> with existing skill_lesson_candidate returns review', async () => {
+  const output = await buildSkillsCommandReply('/skills learn 29', { queryFn: skillQueryMock() });
+  assert.match(output, /Skill lesson review for task #29/);
+  assert.match(output, /Potential lesson to save: Use docker preflight/);
+  assert.match(output, /Selected skills: docker-compose-v1-safety/);
+  assert.match(output, /Missing env: GOOGLE_APPLICATION_CREDENTIALS/);
+  assert.match(output, /Missing tools: docker, psql/);
+  assert.match(output, /Next step: \/skills save-memory 29 or \/skills append-skill 29 <skill-name>/);
+});
+
+test('/skills learn <task_id> with no candidate returns clear message', async () => {
+  const output = await buildSkillsCommandReply('/skills learn 30', { queryFn: skillQueryMock({ candidate: false }) });
+  assert.match(output, /No skill_lesson_candidate found for task #30/);
+});
+
+test('/skills save-memory <task_id> writes hermes_memories using memory_text and memory_type, redacts secrets', async () => {
+  const writes = [];
+  const queryFn = async (sql, params) => {
+    if (/from hermes_tasks/.test(sql)) return { rows: [{ id: params[0], status: 'failed', input_text: 'x' }], rowCount: 1 };
+    if (/from hermes_task_events/.test(sql)) return { rows: [{ event_type: 'skill_lesson_candidate', message: 'x', payload: { lesson_candidate: 'Save token=abc123 DATABASE_URL=postgres://user:pass@db/app https://user:pass@example.com sk-test_1234567890123456' } }], rowCount: 1 };
+    writes.push({ sql, params });
+    if (/insert into hermes_memories/.test(sql)) {
+      assert.match(sql, /memory_text/);
+      assert.match(sql, /memory_type/);
+      assert.doesNotMatch(sql, /\bcontent\b|\btype\b/);
+      assert.equal(params[4], 'ops_sop');
+      assert.doesNotMatch(params[1], /abc123|user:pass|sk-test_1234567890123456|DATABASE_URL=postgres/);
+      return { rows: [{ id: 44, memory_key: params[0], memory_text: params[1], memory_type: params[4] }], rowCount: 1 };
+    }
+    if (/insert into hermes_task_events/.test(sql)) return { rows: [], rowCount: 1 };
+    throw new Error(`unexpected sql: ${sql}`);
+  };
+  const result = await saveSkillLessonToMemory(31, { queryFn });
+  assert.equal(result.ok, true);
+  assert.equal(writes.length, 2);
+  assert.equal(writes[1].params[1], 'skill_lesson_saved_to_memory');
+});
+
+const staleRows = [
+  { id: 1, status: 'pending', input_text: 'old pending task', created_at: '2026-05-10T00:00:00.000Z', approval_expires_at: null, age_seconds: 172800 },
+  { id: 2, status: 'pending_approval', input_text: 'expired approval task', created_at: '2026-05-10T00:00:00.000Z', approval_expires_at: '2026-05-10T00:15:00.000Z', age_seconds: 172800 },
+  { id: 3, status: 'approved', input_text: 'old approved task', created_at: '2026-05-10T00:00:00.000Z', approval_expires_at: null, age_seconds: 172800 },
+  { id: 4, status: 'running', input_text: 'old running task', created_at: '2026-05-11T23:00:00.000Z', approval_expires_at: null, age_seconds: 3600 },
+];
+
+test('/tasks stale lists stale tasks without mutation', async () => {
+  const calls = [];
+  const output = await buildTasksStaleMessage({ queryFn: async (sql, params) => { calls.push({ sql, params }); return { rows: staleRows, rowCount: staleRows.length }; } });
+  assert.match(output, /Stale tasks \(read-only\):/);
+  assert.match(output, /#1 pending/);
+  assert.match(output, /#2 pending_approval/);
+  assert.match(output, /#4 running/);
+  assert.equal(calls.length, 1);
+  assert.doesNotMatch(calls[0].sql, /update|delete/i);
+});
+
+test('/tasks expire-stale mutates only eligible stale pending_approval tasks and logs events', async () => {
+  const writes = [];
+  const result = await expireStaleTasks({
+    operatorAuthorized: true,
+    queryFn: async (sql, params) => {
+      if (/select id,status,input_text/.test(sql)) return { rows: staleRows, rowCount: staleRows.length };
+      writes.push({ sql, params });
+      if (/update hermes_tasks/.test(sql)) {
+        assert.equal(params[0], 2);
+        assert.match(sql, /status='pending_approval'/);
+        assert.equal(params[1], 'Expired by operator stale-task cleanup');
+        return { rows: [{ id: 2, status: 'failed' }], rowCount: 1 };
+      }
+      if (/insert into hermes_task_events/.test(sql)) return { rows: [], rowCount: 1 };
+      throw new Error(`unexpected sql: ${sql}`);
+    },
+  });
+  assert.deepEqual(result.expired, [2]);
+  assert.deepEqual(result.skipped.map((task) => task.id), [1, 3, 4]);
+  assert.equal(writes.filter((write) => /update hermes_tasks/.test(write.sql)).length, 1);
+  assert.deepEqual(writes.filter((write) => /insert into hermes_task_events/.test(write.sql)).map((write) => write.params[1]), ['stale_task_expired', 'status_transition']);
+});
+
+test('/tasks summary returns queue and stale counts', async () => {
+  const output = await buildTasksSummaryMessage({ queryFn: async () => ({ rows: [{ pending: 2, pending_approval: 3, approved: 4, running: 5, completed_24h: 6, failed_24h: 7, oldest_pending_age_seconds: 90000, stale_pending: 1, stale_pending_approval: 2, stale_approved: 3, stale_running: 4 }] }) });
+  assert.match(output, /Tasks summary/);
+  assert.match(output, /pending: 2/);
+  assert.match(output, /completed_24h: 6/);
+  assert.match(output, /stale pending_approval: 2/);
+  assert.match(output, /stale running: 4/);
+});
+
+test('non-operator cannot expire stale tasks', async () => {
+  let called = false;
+  const output = await buildTasksCommandReply('/tasks expire-stale', { operatorAuthorized: false, queryFn: async () => { called = true; return { rows: [] }; } });
+  assert.match(output, /Operator authorization required/);
+  assert.equal(called, false);
+});
+
+test('completed and failed tasks are never modified by expire-stale', async () => {
+  const writes = [];
+  await expireStaleTasks({
+    operatorAuthorized: true,
+    queryFn: async (sql, params) => {
+      if (/select id,status,input_text/.test(sql)) return { rows: [{ id: 8, status: 'completed', input_text: 'done', created_at: '2026-05-01T00:00:00Z' }, { id: 9, status: 'failed', input_text: 'failed', created_at: '2026-05-01T00:00:00Z' }], rowCount: 2 };
+      writes.push({ sql, params });
+      return { rows: [], rowCount: 0 };
+    },
+  });
+  assert.equal(writes.length, 0);
+});
+
+test('running tasks are not expired in v3', async () => {
+  const writes = [];
+  const result = await expireStaleTasks({
+    operatorAuthorized: true,
+    queryFn: async (sql, params) => {
+      if (/select id,status,input_text/.test(sql)) return { rows: [staleRows[3]], rowCount: 1 };
+      writes.push({ sql, params });
+      return { rows: [], rowCount: 0 };
+    },
+  });
+  assert.deepEqual(result.expired, []);
+  assert.equal(writes.length, 0);
+});


### PR DESCRIPTION
### Motivation
- Provide a safe, review-first skill learning flow that surfaces lesson candidates without auto-editing `SKILL.md` or writing memories without explicit operator confirmation.
- Improve visibility into stale tasks and add an operator-gated, non-destructive cleanup path for stale approvals while preserving FSM safety and not touching running/completed/failed rows.
- Keep changes minimal and compatible with existing dispatcher/worker/approval architecture and Skill Layer v2 events.

### Description
- Add `/skills learn <task_id>` review flow that reads `hermes_tasks` and `hermes_task_events`, finds the latest `skill_lesson_candidate`, summarizes task id/status/input, selected skills, missing env/tools, lesson text, and shows the next-step instructions without modifying files or DB. (`index.js` functions: `getSkillLessonReview`, `buildSkillLearnReviewMessage`).
- Add optional `/skills save-memory <task_id>` which redacts secrets and persists reviewed lesson to `hermes_memories` using `memory_text` and `memory_type='ops_sop'`, and logs a `skill_lesson_saved_to_memory` task event; secrets redaction covers credentialed URLs, `DATABASE_URL`, common API key prefixes, and token-like fields. (`index.js` function: `saveSkillLessonToMemory`).
- Implement `/tasks stale`, `/tasks summary`, and operator-gated `/tasks expire-stale` commands that list stale tasks (pending/pending_approval/approved/running thresholds), produce compact Telegram-safe output, and only expire eligible `pending_approval` tasks (writes `stale_task_expired` and `status_transition` events) while skipping non-eligible statuses. (`index.js` helpers: `fetchStaleTasks`, `buildTasksStaleMessage`, `expireStaleTasks`, `buildTasksSummaryMessage`).
- Export new helpers for testing and add unit tests for the new flows; changed files: `index.js` and added `test/skills.v3.test.js` with focused mocks and assertions.

### Testing
- Ran static checks and unit tests: `node --check index.js`, `node --check worker.js`, `node --check skills/registry.js`, `node --check dispatcher/planner.js`, and `node --test test/*.test.js`, and all checks/tests completed successfully with no failures (all automated tests passed).
- New unit tests in `test/skills.v3.test.js` exercise `/skills learn` with/without candidate, `/skills save-memory` redaction and memory insert shape, `/tasks stale` read-only listing, `/tasks expire-stale` operator-gated expiry behavior, and `/tasks summary`; these tests passed. 
- Existing Skill Layer v2 tests remained green after the changes (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a030f98c6a8833384d6f276422c1154)