### PR TITLE
Exclude operator stale-task expirations from HIGH_FAILURE_RATE and avoid duplicate transition events

### DIFF
--- a/dispatcher/health.js
+++ b/dispatcher/health.js
@@ -1,19 +1,20 @@
 const { query } = require('../db');
 const envConfig = require('../config/env');
 
-async function safeQuery(sql, params = []) {
+async function safeQuery(sql, params = [], queryFn = query) {
   try {
-    const result = await query(sql, params);
+    const result = await queryFn(sql, params);
     return { ok: true, rows: result.rows || [] };
   } catch (error) {
     return { ok: false, rows: [], error: error.message };
   }
 }
 
-async function getSystemHealth() {
+async function getSystemHealth(options = {}) {
+  const queryFn = options.queryFn || query;
   const warnings = [];
 
-  const dbPing = await safeQuery('select 1');
+  const dbPing = await safeQuery('select 1', [], queryFn);
   const dbOk = dbPing.ok;
   if (!dbOk) warnings.push(`DB ping failed: ${dbPing.error}`);
 
@@ -23,6 +24,8 @@ async function getSystemHealth() {
          from hermes_worker_status
          order by last_heartbeat_at desc
          limit 1`,
+        [],
+        queryFn,
       )
     : { ok: false, rows: [], error: dbPing.error };
   if (!worker.ok) warnings.push(`Worker status unavailable: ${worker.error}`);
@@ -40,6 +43,8 @@ async function getSystemHealth() {
           coalesce(sum(case when status='failed' and updated_at >= now() - interval '24 hours' then 1 else 0 end), 0)::int as failed_24h,
           coalesce(sum(case when status='failed' then 1 else 0 end), 0)::int as failed_total
          from hermes_tasks`,
+        [],
+        queryFn,
       )
     : { ok: false, rows: [], error: dbPing.error };
   if (!queue.ok) warnings.push(`Queue counts unavailable: ${queue.error}`);
@@ -51,6 +56,8 @@ async function getSystemHealth() {
           coalesce(extract(epoch from (now() - min(case when status='pending_approval' then created_at end)))::int, 0) as oldest_pending_approval_seconds
          from hermes_tasks
          where status in ('pending','pending_approval')`,
+        [],
+        queryFn,
       )
     : { ok: false, rows: [], error: dbPing.error };
   if (!oldest.ok) warnings.push(`Queue age unavailable: ${oldest.error}`);
@@ -61,6 +68,8 @@ async function getSystemHealth() {
          from hermes_tasks
          where status='running'
            and heartbeat_at < now() - interval '10 minutes'`,
+        [],
+        queryFn,
       )
     : { ok: false, rows: [], error: dbPing.error };
   if (!stuck.ok) warnings.push(`Stuck running count unavailable: ${stuck.error}`);
@@ -71,12 +80,14 @@ async function getSystemHealth() {
          from hermes_tasks
          order by id desc
          limit 1`,
+        [],
+        queryFn,
       )
     : { ok: false, rows: [], error: dbPing.error };
   if (!latestTask.ok) warnings.push(`Latest task unavailable: ${latestTask.error}`);
 
   const memory = dbOk
-    ? await safeQuery(`select count(*)::int as total from hermes_memories`)
+    ? await safeQuery(`select count(*)::int as total from hermes_memories`, [], queryFn)
     : { ok: false, rows: [], error: dbPing.error };
   if (!memory.ok) warnings.push(`Memory count unavailable: ${memory.error}`);
 

--- a/dispatcher/monitor.js
+++ b/dispatcher/monitor.js
@@ -19,13 +19,38 @@ async function detectAndHandleStuckTasks() {
   return { stuck: stuck.rowCount || 0 };
 }
 
-async function checkHighFailureRate() {
-  const res = await query(
-    `select count(*)::int as c from hermes_tasks where status='failed' and updated_at > now() - interval '10 minutes'`,
+async function checkHighFailureRate(options = {}) {
+  const queryFn = options.queryFn || query;
+  const alertFn = options.alertFn || triggerAlert;
+  const res = await queryFn(
+    `with recent_failed as (
+       select t.id,t.error_text
+       from hermes_tasks t
+       where t.status='failed'
+         and t.updated_at > now() - interval '10 minutes'
+     ), classified as (
+       select rf.id,
+              (
+                rf.error_text = 'Expired by operator stale-task cleanup'
+                or exists (
+                  select 1
+                  from hermes_task_events e
+                  where e.task_id = rf.id
+                    and e.event_type = 'stale_task_expired'
+                    and e.created_at > now() - interval '10 minutes'
+                )
+              ) as is_cleanup_expiration
+       from recent_failed rf
+     )
+     select
+       coalesce(sum(case when not is_cleanup_expiration then 1 else 0 end),0)::int as failed_last_10m,
+       coalesce(sum(case when is_cleanup_expiration then 1 else 0 end),0)::int as cleanup_expired_last_10m
+     from classified`,
   );
-  const count = res.rows[0]?.c || 0;
-  if (count > 5) await triggerAlert('HIGH_FAILURE_RATE', { failed_last_10m: count });
-  return { failedLast10m: count };
+  const failedLast10m = res.rows[0]?.failed_last_10m || 0;
+  const cleanupExpiredLast10m = res.rows[0]?.cleanup_expired_last_10m || 0;
+  if (failedLast10m > 5) await alertFn('HIGH_FAILURE_RATE', { failed_last_10m: failedLast10m, cleanup_expired_last_10m: cleanupExpiredLast10m });
+  return { failedLast10m, cleanupExpiredLast10m };
 }
 
 async function checkStuckApprovals() {

--- a/index.js
+++ b/index.js
@@ -1073,11 +1073,6 @@ async function expireStaleTasks(options = {}) {
        values ($1,$2,$3,$4::jsonb)`,
       [task.id, 'stale_task_expired', 'Expired by operator stale-task cleanup', JSON.stringify({ previous_status: task.status, new_status: 'failed' })],
     );
-    await queryFn(
-      `insert into hermes_task_events (task_id,event_type,message,payload)
-       values ($1,$2,$3,$4::jsonb)`,
-      [task.id, 'status_transition', 'pending_approval -> failed', JSON.stringify({ reason: 'Expired by operator stale-task cleanup' })],
-    );
   }
   return { ok: true, expired, skipped };
 }

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -1,0 +1,56 @@
+process.env.DISABLE_TELEGRAM = 'true';
+process.env.PROJECT_ROOT_PROD = process.env.PROJECT_ROOT_PROD || '/tmp/hermes-prod-root-for-tests';
+process.env.APP_ENV = process.env.APP_ENV || 'production';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { checkHighFailureRate } = require('../dispatcher/monitor');
+const { getSystemHealth } = require('../dispatcher/health');
+
+test('HIGH_FAILURE_RATE excludes stale cleanup expirations', async () => {
+  const alerts = [];
+  const result = await checkHighFailureRate({
+    queryFn: async (sql) => {
+      assert.match(sql, /Expired by operator stale-task cleanup/);
+      assert.match(sql, /stale_task_expired/);
+      assert.match(sql, /cleanup_expired_last_10m/);
+      return { rows: [{ failed_last_10m: 0, cleanup_expired_last_10m: 7 }], rowCount: 1 };
+    },
+    alertFn: async (...args) => alerts.push(args),
+  });
+
+  assert.deepEqual(result, { failedLast10m: 0, cleanupExpiredLast10m: 7 });
+  assert.equal(alerts.length, 0);
+});
+
+test('HIGH_FAILURE_RATE still triggers for real failures', async () => {
+  const alerts = [];
+  const result = await checkHighFailureRate({
+    queryFn: async () => ({ rows: [{ failed_last_10m: 6, cleanup_expired_last_10m: 7 }], rowCount: 1 }),
+    alertFn: async (...args) => alerts.push(args),
+  });
+
+  assert.deepEqual(result, { failedLast10m: 6, cleanupExpiredLast10m: 7 });
+  assert.deepEqual(alerts, [['HIGH_FAILURE_RATE', { failed_last_10m: 6, cleanup_expired_last_10m: 7 }]]);
+});
+
+test('/health remains OK while failed_24h stays factual', async () => {
+  const result = await getSystemHealth({
+    queryFn: async (sql) => {
+      if (/select 1/.test(sql)) return { rows: [{ '?column?': 1 }], rowCount: 1 };
+      if (/from hermes_worker_status/.test(sql)) return { rows: [{ worker_id: 'worker-1', last_heartbeat_at: '2026-05-12T00:00:00.000Z', status: 'alive' }], rowCount: 1 };
+      if (/from hermes_tasks/.test(sql) && /failed_24h/.test(sql)) return { rows: [{ pending: 0, planned: 0, pending_approval: 0, approved: 0, running: 0, completed_24h: 0, failed_24h: 7, failed_total: 7 }], rowCount: 1 };
+      if (/oldest_pending_seconds/.test(sql)) return { rows: [{ oldest_pending_seconds: 0, oldest_pending_approval_seconds: 0 }], rowCount: 1 };
+      if (/stuck running count/i.test(sql) || /heartbeat_at < now\(\) - interval '10 minutes'/.test(sql)) return { rows: [{ c: 0 }], rowCount: 1 };
+      if (/order by id desc/.test(sql)) return { rows: [{ id: 22, status: 'failed', intent: 'maintenance', input_text: 'expired', created_at: '2026-05-12T00:00:00.000Z', updated_at: '2026-05-12T00:01:00.000Z' }], rowCount: 1 };
+      if (/from hermes_memories/.test(sql)) return { rows: [{ total: 0 }], rowCount: 1 };
+      throw new Error(`unexpected sql: ${sql}`);
+    },
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.equal(result.db.ok, true);
+  assert.equal(result.worker.alive, true);
+  assert.equal(result.queue.failed_24h, 7);
+});

--- a/test/skills.v3.test.js
+++ b/test/skills.v3.test.js
@@ -107,7 +107,27 @@ test('/tasks expire-stale mutates only eligible stale pending_approval tasks and
   assert.deepEqual(result.expired, [2]);
   assert.deepEqual(result.skipped.map((task) => task.id), [1, 3, 4]);
   assert.equal(writes.filter((write) => /update hermes_tasks/.test(write.sql)).length, 1);
-  assert.deepEqual(writes.filter((write) => /insert into hermes_task_events/.test(write.sql)).map((write) => write.params[1]), ['stale_task_expired', 'status_transition']);
+  const eventWrites = writes.filter((write) => /insert into hermes_task_events/.test(write.sql));
+  assert.deepEqual(eventWrites.map((write) => write.params[1]), ['stale_task_expired']);
+  assert.equal(eventWrites.filter((write) => write.params[1] === 'stale_task_expired').length, 1);
+  assert.equal(eventWrites.filter((write) => write.params[1] === 'status_transition').length, 0);
+});
+
+test('/tasks expire-stale relies on the DB trigger for one pending_approval -> failed status_transition', async () => {
+  const writes = [];
+  await expireStaleTasks({
+    operatorAuthorized: true,
+    queryFn: async (sql, params) => {
+      if (/select id,status,input_text/.test(sql)) return { rows: [staleRows[1]], rowCount: 1 };
+      writes.push({ sql, params });
+      if (/update hermes_tasks/.test(sql)) return { rows: [{ id: 2, status: 'failed' }], rowCount: 1 };
+      if (/insert into hermes_task_events/.test(sql)) return { rows: [], rowCount: 1 };
+      throw new Error(`unexpected sql: ${sql}`);
+    },
+  });
+
+  const manualStatusTransitionWrites = writes.filter((write) => /insert into hermes_task_events/.test(write.sql) && write.params[1] === 'status_transition');
+  assert.equal(manualStatusTransitionWrites.length, 0);
 });
 
 test('/tasks summary returns queue and stale counts', async () => {


### PR DESCRIPTION
### Motivation
- Operator-driven /tasks expire-stale previously counted its intentional expirations as failures and could create duplicate `status_transition` events, causing noisy HIGH_FAILURE_RATE alerts and duplicate event rows.
- The goal is to classify cleanup expirations separately for alerting while preserving factual `/health` counts and leaving DB task semantics and triggers intact.

### Description
- Update `checkHighFailureRate` to classify recent failed tasks as cleanup expirations when `error_text = 'Expired by operator stale-task cleanup'` OR a `stale_task_expired` event exists for the task within the 10-minute lookback, and compute both `failed_last_10m` and `cleanup_expired_last_10m`; alerts fire only for non-cleanup failures. (`dispatcher/monitor.js`)
- Remove the manual insert of a `status_transition` event from the `/tasks expire-stale` path so the existing DB trigger is the single writer of transition events; the command still inserts a single `stale_task_expired` event and sets `error_text` on the task. (`index.js`) 
- Make health queries injectable (`queryFn`) to allow deterministic testing of `/health` behavior without changing production semantics. (`dispatcher/health.js`)
- Add/modify tests to cover the new behavior: a new `test/monitor.test.js` verifies cleanup exclusions and `/health` behavior, and `test/skills.v3.test.js` was updated to assert only one `stale_task_expired` is written and no manual `status_transition` inserts occur. (tests under `test/`)
- Files changed: `dispatcher/monitor.js`, `dispatcher/health.js`, `index.js`, `test/monitor.test.js`, `test/skills.v3.test.js`.

### Testing
- Ran syntax checks: `node --check index.js`, `node --check worker.js`, `node --check skills/registry.js`, `node --check dispatcher/planner.js` and they succeeded. 
- Ran unit tests: `node --test test/*.test.js` and all tests passed (37 tests, 0 failures). 
- Ran `git diff --check` to validate whitespace and patch cleanliness and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a034b5881d88333800493bd70ab6df5)