### PR TITLE
Add read-only /host diagnostics and Telegram handler

### DIFF
--- a/dispatcher/hostReadOnly.js
+++ b/dispatcher/hostReadOnly.js
@@ -1,0 +1,288 @@
+const http = require('http');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+const { query } = require('../db');
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_LOG_LINES = 80;
+const MAX_LOG_LINES = 200;
+const HOST_CONTAINERS = {
+  app: 'hermes_app',
+  worker: 'hermes_worker',
+};
+const DOCKER_PS_CONTAINERS = ['hermes_app', 'hermes_worker', 'hermes_db'];
+const HOST_COMMAND_TIMEOUT_MS = 8000;
+const HOST_COMMAND_MAX_BUFFER = 512 * 1024;
+const DB_UNAVAILABLE_MESSAGE = 'psql is host/operator tool required; DB status unavailable from container.';
+
+const BLOCKED_COMMAND_PATTERNS = [
+  /docker-compose\s+down/i,
+  /docker\s+compose\s+down/i,
+  /docker\s+volume\s+rm/i,
+  /docker\s+rm\b/i,
+  /docker\s+rmi\b/i,
+  /rm\s+-rf/i,
+  /\bDROP\b/i,
+  /\bDELETE\b/i,
+  /\bUPDATE\b/i,
+  /\bINSERT\b/i,
+  /\bALTER\b/i,
+  /\bTRUNCATE\b/i,
+  /git\s+reset\b/i,
+  /git\s+checkout\b/i,
+  /git\s+pull\b/i,
+  /git\s+push\b/i,
+  /git\s+merge\b/i,
+];
+
+function redactSensitiveText(text = '') {
+  let redacted = String(text || '');
+
+  redacted = redacted.replace(
+    /\b(TELEGRAM_BOT_TOKEN|TELEGRAM_TOKEN|DEEPSEEK_API_KEY|DATABASE_URL|GH_TOKEN|GITHUB_TOKEN|GOOGLE_APPLICATION_CREDENTIALS)\b\s*[:=]\s*([^\s'"`]+)/gi,
+    '$1=[REDACTED]',
+  );
+  redacted = redacted.replace(/postgres(?:ql)?:\/\/[^\s'"`]+/gi, 'postgres://[REDACTED]');
+  redacted = redacted.replace(/https?:\/\/([^:\s'"`/@]+):([^@\s'"`]+)@/gi, 'https://[REDACTED]@');
+  redacted = redacted.replace(/\b(Bearer)\s+[A-Za-z0-9._~+\/-]+=*/gi, '$1 [REDACTED]');
+  redacted = redacted.replace(/\b(token|api[_-]?key|apikey|authorization|password|passwd|pwd|secret|bearer|key)\b\s*[:=]\s*(?:Bearer\s+)?([^\s'"`]+)/gi, '$1=[REDACTED]');
+  redacted = redacted.replace(/\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b/g, '[REDACTED_GITHUB_TOKEN]');
+  redacted = redacted.replace(/\bsk-[A-Za-z0-9_-]{16,}\b/g, '[REDACTED_API_KEY]');
+  redacted = redacted.replace(/\b[A-Za-z0-9_-]{24,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}\b/g, '[REDACTED_TOKEN]');
+
+  return redacted;
+}
+
+function parseLogLineLimit(value) {
+  const parsed = Number.parseInt(String(value || '').trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LOG_LINES;
+  return Math.min(parsed, MAX_LOG_LINES);
+}
+
+function assertNoBlockedCommand(commandText) {
+  const candidate = Array.isArray(commandText) ? commandText.join(' ') : String(commandText || '');
+  const blocked = BLOCKED_COMMAND_PATTERNS.find((pattern) => pattern.test(candidate));
+  if (blocked) {
+    const err = new Error('host_readonly_command_blocked');
+    err.code = 'host_readonly_command_blocked';
+    err.pattern = String(blocked);
+    throw err;
+  }
+  return true;
+}
+
+function commandToText(file, args = []) {
+  return [file, ...args].join(' ');
+}
+
+function buildDockerPsCommand() {
+  const args = [
+    'ps',
+    '--filter', 'name=^/hermes_app$',
+    '--filter', 'name=^/hermes_worker$',
+    '--filter', 'name=^/hermes_db$',
+    '--format', '{{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Ports}}',
+  ];
+  assertNoBlockedCommand(commandToText('docker', args));
+  return { file: 'docker', args, label: 'docker ps hermes containers' };
+}
+
+function buildDockerLogsCommand(target, lineValue) {
+  if (!Object.prototype.hasOwnProperty.call(HOST_CONTAINERS, target)) {
+    throw new Error('invalid_host_logs_target');
+  }
+  const lines = parseLogLineLimit(lineValue);
+  const args = ['logs', `--tail=${lines}`, HOST_CONTAINERS[target]];
+  assertNoBlockedCommand(commandToText('docker', args));
+  return { file: 'docker', args, label: `docker logs ${HOST_CONTAINERS[target]} --tail=${lines}`, lines, container: HOST_CONTAINERS[target] };
+}
+
+function buildGitStatusCommands() {
+  const commands = [
+    { file: 'git', args: ['status', '--short'], label: 'git status --short' },
+    { file: 'git', args: ['log', '--oneline', '--decorate', '-5'], label: 'git log --oneline --decorate -5' },
+  ];
+  for (const command of commands) assertNoBlockedCommand(commandToText(command.file, command.args));
+  return commands;
+}
+
+async function runReadOnlyCommand(command, options = {}) {
+  assertNoBlockedCommand(commandToText(command.file, command.args));
+  const execFileFn = options.execFileFn || execFileAsync;
+  try {
+    const result = await execFileFn(command.file, command.args, {
+      cwd: options.cwd || process.cwd(),
+      shell: false,
+      timeout: options.timeout || HOST_COMMAND_TIMEOUT_MS,
+      maxBuffer: options.maxBuffer || HOST_COMMAND_MAX_BUFFER,
+      env: process.env,
+    });
+    return { ok: true, stdout: redactSensitiveText(result.stdout || ''), stderr: redactSensitiveText(result.stderr || '') };
+  } catch (err) {
+    return {
+      ok: false,
+      stdout: redactSensitiveText(err.stdout || ''),
+      stderr: redactSensitiveText(err.stderr || err.message || 'command_failed'),
+    };
+  }
+}
+
+function fetchLocalHealth(options = {}) {
+  if (options.healthFetcher) return options.healthFetcher();
+  return new Promise((resolve) => {
+    const req = http.get('http://localhost:3000/health', { timeout: 4000 }, (res) => {
+      let body = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => { body += chunk; });
+      res.on('end', () => {
+        try {
+          resolve({ ok: res.statusCode >= 200 && res.statusCode < 300, statusCode: res.statusCode, data: JSON.parse(body) });
+        } catch (err) {
+          resolve({ ok: false, statusCode: res.statusCode, error: err.message, raw: body });
+        }
+      });
+    });
+    req.on('timeout', () => req.destroy(new Error('health_request_timeout')));
+    req.on('error', (err) => resolve({ ok: false, error: err.message }));
+  });
+}
+
+function formatHostHealth(healthResult) {
+  const health = healthResult?.data || healthResult || {};
+  const queue = health.queue || {};
+  const warnings = Array.isArray(health.warnings) ? health.warnings : [];
+  return redactSensitiveText([
+    'Host Health (read-only)',
+    `- status: ${health.status || (healthResult?.ok ? 'ok' : 'unknown')}`,
+    `- db.ok: ${health.db?.ok === true ? 'true' : 'false'}`,
+    `- worker.alive: ${health.worker?.alive === true ? 'true' : 'false'}`,
+    `- queue.pending: ${queue.pending || 0}`,
+    `- queue.pending_approval: ${queue.pending_approval || 0}`,
+    `- queue.running: ${queue.running || 0}`,
+    `- queue.stuck_running: ${queue.stuck_running || 0}`,
+    `- warnings: ${warnings.length ? warnings.slice(0, 5).join('; ') : 'none'}`,
+  ].join('\n'));
+}
+
+function formatDockerPsOutput(result) {
+  if (!result.ok) return `Host docker-ps (read-only)\n- unavailable: ${redactSensitiveText(result.stderr || 'docker ps failed')}`;
+  const lines = String(result.stdout || '').trim().split('\n').filter(Boolean);
+  if (!lines.length) return 'Host docker-ps (read-only)\n- no hermes containers found';
+  const rows = lines.map((line) => {
+    const [name = '-', status = '-', image = '-', ports = '-'] = line.split('\t');
+    return `- ${name}: ${status} | image=${image || '-'} | ports=${ports || '-'}`;
+  });
+  return redactSensitiveText(['Host docker-ps (read-only)', ...rows].join('\n'));
+}
+
+function formatLogsOutput(target, command, result) {
+  const header = `Host logs ${target} (read-only, tail=${command.lines})`;
+  const output = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+  if (!result.ok && !output) return `${header}\n- unavailable: docker logs failed`;
+  return redactSensitiveText(`${header}\n${output || '- no log output'}`).slice(0, 3500);
+}
+
+function formatGitStatusOutput(results) {
+  const [status, log] = results;
+  return redactSensitiveText([
+    'Host git-status (read-only)',
+    '$ git status --short',
+    status.ok ? (status.stdout.trim() || '(clean)') : `unavailable: ${status.stderr || 'git status failed'}`,
+    '',
+    '$ git log --oneline --decorate -5',
+    log.ok ? (log.stdout.trim() || '(no commits)') : `unavailable: ${log.stderr || 'git log failed'}`,
+  ].join('\n')).slice(0, 3500);
+}
+
+async function buildDbStatusMessage(options = {}) {
+  const queryFn = options.queryFn || query;
+  if (!process.env.DATABASE_URL && !options.queryFn) return DB_UNAVAILABLE_MESSAGE;
+  const output = ['Host DB status (read-only)'];
+  try {
+    const now = await queryFn('SELECT now();');
+    output.push(`- now: ${now.rows?.[0]?.now ? new Date(now.rows[0].now).toISOString() : '-'}`);
+
+    const counts = await queryFn('SELECT status, COUNT(*)::int AS count FROM hermes_tasks GROUP BY status ORDER BY status;');
+    const countRows = counts.rows || [];
+    output.push('- task status counts:');
+    output.push(...(countRows.length ? countRows.map((row) => `  - ${row.status}: ${row.count}`) : ['  - none: 0']));
+
+    const table = await queryFn("SELECT to_regclass('public.hermes_worker_status') AS table_name;");
+    if (table.rows?.[0]?.table_name) {
+      const workers = await queryFn('SELECT worker_id,last_heartbeat_at,status FROM hermes_worker_status ORDER BY last_heartbeat_at DESC LIMIT 3;');
+      output.push('- worker heartbeat:');
+      output.push(...((workers.rows || []).length ? workers.rows.map((row) => `  - ${row.worker_id || '-'} ${row.status || '-'} ${row.last_heartbeat_at ? new Date(row.last_heartbeat_at).toISOString() : '-'}`) : ['  - none']));
+    } else {
+      output.push('- worker heartbeat: hermes_worker_status table not found');
+    }
+  } catch (err) {
+    return `${DB_UNAVAILABLE_MESSAGE}\n- detail: ${redactSensitiveText(err.message || 'query failed')}`;
+  }
+  return redactSensitiveText(output.join('\n')).slice(0, 3500);
+}
+
+function isHostCommand(text = '') {
+  return /^\/host(?:@\w+)?(?:\s|$)/i.test(String(text || '').trim());
+}
+
+function isOperatorAuthorized(userId, allowedUserIds = []) {
+  return allowedUserIds.map(Number).includes(Number(userId));
+}
+
+async function buildHostCommandReply(text, options = {}) {
+  const input = String(text || '').trim();
+  const allowedUserIds = options.allowedUserIds || [];
+  if (!isOperatorAuthorized(options.userId, allowedUserIds)) {
+    return 'Operator authorization required for /host commands.';
+  }
+
+  if (/^\/host(?:@\w+)?\s+health$/i.test(input)) {
+    return formatHostHealth(await fetchLocalHealth(options));
+  }
+
+  if (/^\/host(?:@\w+)?\s+docker-ps$/i.test(input)) {
+    const command = buildDockerPsCommand();
+    return formatDockerPsOutput(await runReadOnlyCommand(command, options));
+  }
+
+  const logsMatch = input.match(/^\/host(?:@\w+)?\s+logs\s+(\S+)(?:\s+(\S+))?$/i);
+  if (logsMatch) {
+    const target = String(logsMatch[1] || '').toLowerCase();
+    if (!Object.prototype.hasOwnProperty.call(HOST_CONTAINERS, target)) {
+      return 'Dùng: /host logs app [lines] hoặc /host logs worker [lines]';
+    }
+    const command = buildDockerLogsCommand(target, logsMatch[2]);
+    return formatLogsOutput(target, command, await runReadOnlyCommand(command, options));
+  }
+
+  if (/^\/host(?:@\w+)?\s+db-status$/i.test(input)) {
+    return buildDbStatusMessage(options);
+  }
+
+  if (/^\/host(?:@\w+)?\s+git-status$/i.test(input)) {
+    const commands = buildGitStatusCommands();
+    const results = [];
+    for (const command of commands) results.push(await runReadOnlyCommand(command, { ...options, cwd: options.repoRoot || process.cwd() }));
+    return formatGitStatusOutput(results);
+  }
+
+  return 'Dùng: /host health | docker-ps | logs app [lines] | logs worker [lines] | db-status | git-status';
+}
+
+module.exports = {
+  BLOCKED_COMMAND_PATTERNS,
+  DEFAULT_LOG_LINES,
+  MAX_LOG_LINES,
+  DB_UNAVAILABLE_MESSAGE,
+  redactSensitiveText,
+  parseLogLineLimit,
+  assertNoBlockedCommand,
+  buildDockerPsCommand,
+  buildDockerLogsCommand,
+  buildGitStatusCommands,
+  buildDbStatusMessage,
+  buildHostCommandReply,
+  isHostCommand,
+  isOperatorAuthorized,
+};

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ const {
   buildDeployCheck,
 } = require("./gbrain");
 const { isExternalCliTask, routeTool, buildExternalCliApprovalPlan } = require('./dispatcher/externalCliTools');
+const { isHostCommand, buildHostCommandReply } = require('./dispatcher/hostReadOnly');
 const app = express();
 app.use(express.json());
 
@@ -1874,6 +1875,20 @@ if (callback) {
       }
 
 
+      if (isHostCommand(text)) {
+        try {
+          await sendTelegramMessage(chatId, await buildHostCommandReply(text, {
+            userId,
+            allowedUserIds: ALLOWED_USER_IDS,
+            repoRoot: process.cwd(),
+          }));
+        } catch (err) {
+          await sendTelegramMessage(chatId, `Lỗi /host: ${truncateForTelegram(err.message, 200)}`);
+        }
+        console.log("COMMAND_HANDLED /host", { userId, chatId });
+        continue;
+      }
+
       if (normalized === "/skills" || normalized === "/skills list" || normalized.startsWith("/skills match ") || normalized.startsWith("/skills show ") || normalized.startsWith("/skills why ") || normalized === "/skills doctor" || normalized.startsWith("/skills learn") || normalized.startsWith("/skills save-memory")) {
         try {
           await sendTelegramMessage(chatId, await buildSkillsCommandReply(text));
@@ -2054,6 +2069,7 @@ if (callback) {
   await sendTelegramMessage(chatId, `📚 Hermes Commands
 
 /status — system health
+/host health|docker-ps|logs app|logs worker|db-status|git-status — read-only host diagnostics
 /queue — queue summary
 /tasks summary|stale|expire-stale — task hygiene
 /pending — pending approvals
@@ -2799,6 +2815,8 @@ module.exports = {
   expireStaleTasks,
   buildTasksExpireStaleMessage,
   buildTasksSummaryMessage,
+  buildHostCommandReply,
+  isHostCommand,
   isTaskStale,
   isCasualTelegramInput,
   isTaskLikeTelegramInput,

--- a/test/hostReadOnly.test.js
+++ b/test/hostReadOnly.test.js
@@ -1,0 +1,144 @@
+process.env.DISABLE_TELEGRAM = 'true';
+process.env.APP_ENV = process.env.APP_ENV || 'staging';
+process.env.PROJECT_ROOT_PROD = process.env.PROJECT_ROOT_PROD || '/tmp/hermes-prod-root-for-tests';
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://user:password@localhost:5432/hermes';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  buildDockerLogsCommand,
+  buildDockerPsCommand,
+  buildGitStatusCommands,
+  buildHostCommandReply,
+  assertNoBlockedCommand,
+  isHostCommand,
+  redactSensitiveText,
+} = require('../dispatcher/hostReadOnly');
+const { isTaskLikeTelegramInput } = require('../index');
+
+const operatorOptions = {
+  userId: 42,
+  allowedUserIds: [42],
+};
+
+test('/host health is recognized for early routing before task creation', async () => {
+  assert.equal(isHostCommand('/host health'), true);
+  assert.equal(isTaskLikeTelegramInput('/host health'), false);
+  const reply = await buildHostCommandReply('/host health', {
+    ...operatorOptions,
+    healthFetcher: async () => ({
+      ok: true,
+      data: {
+        status: 'ok',
+        db: { ok: true },
+        worker: { alive: true },
+        queue: { pending: 1, pending_approval: 2, running: 3, stuck_running: 4 },
+        warnings: ['sample warning'],
+      },
+    }),
+  });
+  assert.match(reply, /Host Health \(read-only\)/);
+  assert.match(reply, /status: ok/);
+  assert.match(reply, /db\.ok: true/);
+  assert.match(reply, /worker\.alive: true/);
+  assert.match(reply, /queue\.pending: 1/);
+  assert.match(reply, /queue\.pending_approval: 2/);
+  assert.match(reply, /queue\.running: 3/);
+  assert.match(reply, /queue\.stuck_running: 4/);
+  assert.match(reply, /sample warning/);
+});
+
+test('/host docker-ps uses allowlisted docker ps command only', () => {
+  const command = buildDockerPsCommand();
+  assert.equal(command.file, 'docker');
+  assert.deepEqual(command.args.slice(0, 1), ['ps']);
+  assert.equal(command.args.includes('down'), false);
+  assert.equal(command.args.includes('rm'), false);
+  assert.equal(command.args.includes('rmi'), false);
+  assert.doesNotThrow(() => assertNoBlockedCommand([command.file, ...command.args]));
+});
+
+test('/host logs app caps lines at 200', () => {
+  const command = buildDockerLogsCommand('app', '9999');
+  assert.equal(command.file, 'docker');
+  assert.deepEqual(command.args, ['logs', '--tail=200', 'hermes_app']);
+  assert.equal(command.lines, 200);
+});
+
+test('/host logs worker caps lines at 200', () => {
+  const command = buildDockerLogsCommand('worker', '500');
+  assert.equal(command.file, 'docker');
+  assert.deepEqual(command.args, ['logs', '--tail=200', 'hermes_worker']);
+  assert.equal(command.lines, 200);
+});
+
+test('invalid /host logs target is rejected', async () => {
+  const reply = await buildHostCommandReply('/host logs db 80', operatorOptions);
+  assert.match(reply, /Dùng: \/host logs app \[lines\] hoặc \/host logs worker \[lines\]/);
+});
+
+test('unsafe commands are blocked by guard', () => {
+  const unsafeCommands = [
+    'docker-compose down',
+    'docker compose down',
+    'docker volume rm hermes_db',
+    'docker rm hermes_app',
+    'docker rmi image',
+    'rm -rf /',
+    'DROP TABLE hermes_tasks',
+    'DELETE FROM hermes_tasks',
+    'UPDATE hermes_tasks SET status=failed',
+    'INSERT INTO hermes_tasks DEFAULT VALUES',
+    'ALTER TABLE hermes_tasks ADD COLUMN x text',
+    'TRUNCATE hermes_tasks',
+    'git reset --hard HEAD',
+    'git checkout main',
+    'git pull',
+    'git push',
+    'git merge main',
+  ];
+  for (const command of unsafeCommands) {
+    assert.throws(() => assertNoBlockedCommand(command), /host_readonly_command_blocked/);
+  }
+});
+
+test('redaction removes DATABASE_URL/token/password/API key values', () => {
+  const input = [
+    'DATABASE_URL=postgres://user:pass@db:5432/hermes',
+    'TELEGRAM_BOT_TOKEN=123456:ABCDEF_secret',
+    'GH_TOKEN=ghp_123456789012345678901234567890123456',
+    'password=swordfish',
+    'api_key=sk-abcdefghijklmnopqrstuvwxyz123456',
+    'Authorization: Bearer abc.defghijklmnopqrstuvwxyz.12345678901234567890',
+  ].join('\n');
+  const output = redactSensitiveText(input);
+  assert.doesNotMatch(output, /user:pass|swordfish|abcdefghijklmnopqrstuvwxyz123456|ghp_123456|ABCDEF_secret|abc\.defgh/);
+  assert.match(output, /DATABASE_URL=\[REDACTED\]/);
+  assert.match(output, /password=\[REDACTED\]/i);
+});
+
+test('non-operator cannot use /host commands', async () => {
+  const reply = await buildHostCommandReply('/host health', { userId: 7, allowedUserIds: [42] });
+  assert.match(reply, /Operator authorization required/);
+});
+
+test('/host git-status does not run git pull/push/checkout/reset/merge', async () => {
+  const commands = buildGitStatusCommands();
+  assert.deepEqual(commands.map((command) => [command.file, command.args]), [
+    ['git', ['status', '--short']],
+    ['git', ['log', '--oneline', '--decorate', '-5']],
+  ]);
+  const seen = [];
+  const reply = await buildHostCommandReply('/host git-status', {
+    ...operatorOptions,
+    execFileFn: async (file, args) => {
+      seen.push([file, args]);
+      return { stdout: file === 'git' && args[0] === 'status' ? ' M index.js\n' : 'abc123 (HEAD) test commit\n', stderr: '' };
+    },
+  });
+  const joined = seen.map(([file, args]) => [file, ...args].join(' ')).join('\n');
+  assert.doesNotMatch(joined, /git (pull|push|checkout|reset|merge)\b/);
+  assert.match(reply, /git status --short/);
+  assert.match(reply, /git log --oneline --decorate -5/);
+});


### PR DESCRIPTION
### Motivation
- Provide operators a safe, read-only host diagnostic surface so Hermes can inspect app/worker/db/container/git state without running destructive commands or creating `hermes_tasks` rows.
- Ensure diagnostics are operator-only, use an allowlist for commands, cap log lines, and redact any secrets/env values before returning output.
- Centralize guard logic to block destructive keywords (e.g., `docker-compose down`, `rm -rf`, `DROP`, `git pull`) and avoid shell interpolation of arbitrary user input.

### Description
- Added a new read-only host dispatcher at `dispatcher/hostReadOnly.js` that implements builders for allowed commands (`docker ps`, `docker logs`, `git status`/`git log`), a DB-only read path (`SELECT now();`, task counts, optional `hermes_worker_status`), redaction helpers, line-limit parsing, and a blocked-command pattern list.
- Wired early routing in `index.js` so `/host` commands are handled before the generic task creation path and therefore do not insert `hermes_tasks` rows, plus added help text and exports for testing (`buildHostCommandReply`, `isHostCommand`).
- Enforced execution safety by using non-shell `execFile`, explicit command builders, `assertNoBlockedCommand` checks, bounded timeouts/buffers, and a DB-unavailable fallback message when `psql`/`DATABASE_URL` is not reachable.
- Added `test/hostReadOnly.test.js` to cover routing-before-task-creation, docker-ps allowlist, log-line caps (max 200), invalid log targets, blocked/unsafe commands, secret redaction (tokens/URLs/passwords), operator authorization, and git-status read-only behavior.

### Testing
- Ran static checks and unit tests: `node --check index.js`, `node --check worker.js`, `node --check skills/registry.js`, `node --check dispatcher/planner.js`, `node --check dispatcher/hostReadOnly.js` — all passed.
- Executed unit suite: `node --test test/*.test.js` — all tests passed (46 tests, 0 failures), including `test/hostReadOnly.test.js`.
- Ran `git diff --check` to validate no whitespace/git issues — clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a035124687c83338744167eb21e78b7)