### PR TITLE
Handle missing Docker CLI in /host diagnostics with safe unavailable message

### DIFF
--- a/dispatcher/hostReadOnly.js
+++ b/dispatcher/hostReadOnly.js
@@ -15,6 +15,7 @@ const DOCKER_PS_CONTAINERS = ['hermes_app', 'hermes_worker', 'hermes_db'];
 const HOST_COMMAND_TIMEOUT_MS = 8000;
 const HOST_COMMAND_MAX_BUFFER = 512 * 1024;
 const DB_UNAVAILABLE_MESSAGE = 'psql is host/operator tool required; DB status unavailable from container.';
+const DOCKER_HOST_DIAGNOSTICS_UNAVAILABLE_MESSAGE = 'Docker host diagnostics unavailable from this container. docker CLI is not installed and no safe host wrapper is configured.';
 
 const BLOCKED_COMMAND_PATTERNS = [
   /docker-compose\s+down/i,
@@ -107,6 +108,14 @@ function buildGitStatusCommands() {
   return commands;
 }
 
+function isMissingDockerCliError(command, err = {}) {
+  if (command?.file !== 'docker') return false;
+  const detail = [err.code, err.errno, err.syscall, err.path, err.message, err.stderr]
+    .filter(Boolean)
+    .join(' ');
+  return /\bENOENT\b/i.test(detail) || /spawn\s+docker\s+ENOENT/i.test(detail);
+}
+
 async function runReadOnlyCommand(command, options = {}) {
   assertNoBlockedCommand(commandToText(command.file, command.args));
   const execFileFn = options.execFileFn || execFileAsync;
@@ -120,6 +129,14 @@ async function runReadOnlyCommand(command, options = {}) {
     });
     return { ok: true, stdout: redactSensitiveText(result.stdout || ''), stderr: redactSensitiveText(result.stderr || '') };
   } catch (err) {
+    if (isMissingDockerCliError(command, err)) {
+      return {
+        ok: false,
+        stdout: '',
+        stderr: DOCKER_HOST_DIAGNOSTICS_UNAVAILABLE_MESSAGE,
+        unavailableReason: 'docker_cli_missing',
+      };
+    }
     return {
       ok: false,
       stdout: redactSensitiveText(err.stdout || ''),
@@ -165,7 +182,13 @@ function formatHostHealth(healthResult) {
   ].join('\n'));
 }
 
+function isDockerDiagnosticsUnavailable(result = {}) {
+  return result.unavailableReason === 'docker_cli_missing'
+    || result.stderr === DOCKER_HOST_DIAGNOSTICS_UNAVAILABLE_MESSAGE;
+}
+
 function formatDockerPsOutput(result) {
+  if (isDockerDiagnosticsUnavailable(result)) return DOCKER_HOST_DIAGNOSTICS_UNAVAILABLE_MESSAGE;
   if (!result.ok) return `Host docker-ps (read-only)\n- unavailable: ${redactSensitiveText(result.stderr || 'docker ps failed')}`;
   const lines = String(result.stdout || '').trim().split('\n').filter(Boolean);
   if (!lines.length) return 'Host docker-ps (read-only)\n- no hermes containers found';
@@ -177,6 +200,7 @@ function formatDockerPsOutput(result) {
 }
 
 function formatLogsOutput(target, command, result) {
+  if (isDockerDiagnosticsUnavailable(result)) return DOCKER_HOST_DIAGNOSTICS_UNAVAILABLE_MESSAGE;
   const header = `Host logs ${target} (read-only, tail=${command.lines})`;
   const output = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
   if (!result.ok && !output) return `${header}\n- unavailable: docker logs failed`;
@@ -275,6 +299,7 @@ module.exports = {
   DEFAULT_LOG_LINES,
   MAX_LOG_LINES,
   DB_UNAVAILABLE_MESSAGE,
+  DOCKER_HOST_DIAGNOSTICS_UNAVAILABLE_MESSAGE,
   redactSensitiveText,
   parseLogLineLimit,
   assertNoBlockedCommand,
@@ -282,6 +307,7 @@ module.exports = {
   buildDockerLogsCommand,
   buildGitStatusCommands,
   buildDbStatusMessage,
+  runReadOnlyCommand,
   buildHostCommandReply,
   isHostCommand,
   isOperatorAuthorized,

--- a/test/hostReadOnly.test.js
+++ b/test/hostReadOnly.test.js
@@ -11,6 +11,7 @@ const {
   buildDockerPsCommand,
   buildGitStatusCommands,
   buildHostCommandReply,
+  DOCKER_HOST_DIAGNOSTICS_UNAVAILABLE_MESSAGE,
   assertNoBlockedCommand,
   isHostCommand,
   redactSensitiveText,
@@ -21,6 +22,14 @@ const operatorOptions = {
   userId: 42,
   allowedUserIds: [42],
 };
+
+function missingDockerError() {
+  const err = new Error('spawn docker ENOENT');
+  err.code = 'ENOENT';
+  err.syscall = 'spawn docker';
+  err.path = 'docker';
+  return err;
+}
 
 test('/host health is recognized for early routing before task creation', async () => {
   assert.equal(isHostCommand('/host health'), true);
@@ -49,6 +58,47 @@ test('/host health is recognized for early routing before task creation', async 
   assert.match(reply, /sample warning/);
 });
 
+test('/host docker-ps returns safe unavailable message when docker CLI is missing', async () => {
+  const seen = [];
+  const reply = await buildHostCommandReply('/host docker-ps', {
+    ...operatorOptions,
+    execFileFn: async (file, args) => {
+      seen.push([file, args]);
+      throw missingDockerError();
+    },
+  });
+
+  assert.equal(reply, DOCKER_HOST_DIAGNOSTICS_UNAVAILABLE_MESSAGE);
+  assert.deepEqual(seen, [[buildDockerPsCommand().file, buildDockerPsCommand().args]]);
+});
+
+test('/host logs app and worker return safe unavailable message when docker CLI is missing', async () => {
+  for (const target of ['app', 'worker']) {
+    const reply = await buildHostCommandReply(`/host logs ${target} 80`, {
+      ...operatorOptions,
+      execFileFn: async () => {
+        throw missingDockerError();
+      },
+    });
+
+    assert.equal(reply, DOCKER_HOST_DIAGNOSTICS_UNAVAILABLE_MESSAGE);
+  }
+});
+
+test('raw spawn docker ENOENT is not exposed to Telegram /host replies', async () => {
+  for (const command of ['/host docker-ps', '/host logs app 80', '/host logs worker 80']) {
+    const reply = await buildHostCommandReply(command, {
+      ...operatorOptions,
+      execFileFn: async () => {
+        throw missingDockerError();
+      },
+    });
+
+    assert.doesNotMatch(reply, /spawn docker ENOENT|ENOENT/);
+    assert.match(reply, /Docker host diagnostics unavailable from this container/);
+  }
+});
+
 test('/host docker-ps uses allowlisted docker ps command only', () => {
   const command = buildDockerPsCommand();
   assert.equal(command.file, 'docker');
@@ -57,6 +107,25 @@ test('/host docker-ps uses allowlisted docker ps command only', () => {
   assert.equal(command.args.includes('rm'), false);
   assert.equal(command.args.includes('rmi'), false);
   assert.doesNotThrow(() => assertNoBlockedCommand([command.file, ...command.args]));
+});
+
+test('/host docker-ps remains read-only and never uses docker socket or compose', async () => {
+  const seen = [];
+  await buildHostCommandReply('/host docker-ps', {
+    ...operatorOptions,
+    execFileFn: async (file, args, opts) => {
+      seen.push({ file, args, opts });
+      return { stdout: 'hermes_app\tUp 1 minute\thermes-app:latest\t3000/tcp\n', stderr: '' };
+    },
+  });
+
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].file, 'docker');
+  assert.deepEqual(seen[0].args.slice(0, 1), ['ps']);
+  assert.equal(seen[0].opts.shell, false);
+  const commandText = [seen[0].file, ...seen[0].args].join(' ');
+  assert.doesNotMatch(commandText, /docker-compose|docker compose|restart|rm\b|rmi\b|create/);
+  assert.doesNotMatch(commandText, /docker\.sock|\/var\/run\/docker\.sock/);
 });
 
 test('/host logs app caps lines at 200', () => {
@@ -71,6 +140,26 @@ test('/host logs worker caps lines at 200', () => {
   assert.equal(command.file, 'docker');
   assert.deepEqual(command.args, ['logs', '--tail=200', 'hermes_worker']);
   assert.equal(command.lines, 200);
+});
+
+test('/host logs app and worker remain bounded to max 200 lines', async () => {
+  for (const target of ['app', 'worker']) {
+    const seen = [];
+    const reply = await buildHostCommandReply(`/host logs ${target} 9999`, {
+      ...operatorOptions,
+      execFileFn: async (file, args, opts) => {
+        seen.push({ file, args, opts });
+        return { stdout: 'line\n'.repeat(250), stderr: '' };
+      },
+    });
+
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].file, 'docker');
+    assert.deepEqual(seen[0].args.slice(0, 2), ['logs', '--tail=200']);
+    assert.equal(seen[0].opts.shell, false);
+    assert.match(reply, new RegExp(`Host logs ${target} \\(read-only, tail=200\\)`));
+    assert.ok(reply.length <= 3500);
+  }
 });
 
 test('invalid /host logs target is rejected', async () => {


### PR DESCRIPTION
### Motivation
- Prevent exposing raw `spawn docker ENOENT` errors from the container when the Docker CLI is not installed and no safe host wrapper is configured. 
- Provide a clear, operator-friendly unavailable message for read-only Docker diagnostics endpoints (`/host docker-ps` and `/host logs`) while keeping diagnostics read-only and safe.

### Description
- Added `DOCKER_HOST_DIAGNOSTICS_UNAVAILABLE_MESSAGE` and an `isMissingDockerCliError` detector to map Docker `ENOENT`/spawn failures into a safe unavailable result. 
- Updated `runReadOnlyCommand` to return a normalized unavailable response (`unavailableReason: 'docker_cli_missing'`) for missing Docker CLI errors and preserved redaction of stdout/stderr for other failures. 
- Updated `formatDockerPsOutput` and `formatLogsOutput` to return the safe unavailable message when Docker diagnostics are unavailable for the detected reason. 
- Added tests in `test/hostReadOnly.test.js` to cover: missing Docker CLI returns the safe message, raw `spawn docker ENOENT` is not exposed in Telegram replies, `/host docker-ps` remains read-only (no socket/compose), and `/host logs app|worker` remain bounded to max lines. 
- Files changed: `dispatcher/hostReadOnly.js` and `test/hostReadOnly.test.js`.
- Preserved existing safety constraints: no Docker socket mounting or socket support added, no `docker-compose` execution, no restart/remove/create commands introduced, `/host health` and `/host git-status` behavior unchanged, `hermes_tasks` writes unaffected, and secret redaction remains intact.

### Testing
- Ran `node --check index.js` and it succeeded. 
- Ran `node --check dispatcher/hostReadOnly.js` and it succeeded. 
- Ran unit tests with `node --test test/*.test.js` and all tests passed (51 tests, 0 failures). 
- Ran `git diff --check` and found no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0356faed308333b671df5147e78b28)